### PR TITLE
docs: bump README version header to 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 -->
 
 # Praxen
-**agent behavior verifier · Version 0.6.3**
+**agent behavior verifier · Version 0.7.0**
 
 > *Make sure your agent does its job — and only its job.*
 


### PR DESCRIPTION
One-line fix: the version line on the README's title block still read `Version 0.6.3` — a fossil the rename PR missed. Everywhere else is 0.7.0 (PRAXEN_SPEC, plugin manifests, SKILL.md `praxen_version` literal, the live GitHub release). This brings the README into line.

Spot-checked the rest of the repo for stray `0.6.3` references — the only other hits are intentional historical context in `tests/README.md` and `tests/baselines/README.md` referring to the retired `v0.6.3-sequential/` baseline directory name.