### PR TITLE
docs: community standards files (SECURITY, CoC, issue/PR templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
       value: |
         Thanks for taking the time to file a bug. A few notes before you start:
 
-        - **For security vulnerabilities, do not use this form** — use the private security advisory link on the previous page (or follow [SECURITY.md](../blob/main/SECURITY.md)).
+        - **For security vulnerabilities, do not use this form** — use the private security advisory link on the previous page (or follow [SECURITY.md](/SECURITY.md)).
         - **Findings _about_ an analyzed agent are not bugs in Praxen.** Those are normal output of running the scanner. Report them to that agent's own maintainer, not here.
         - A reproducible bug report with concrete inputs (a minimal Worker Remit + a scan target, or a hand-crafted findings JSON) is the fastest path to a fix.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug report
+description: A concrete defect — Praxen does something wrong, or fails to do something it should.
+title: "bug: "
+labels: ["bug"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. A few notes before you start:
+
+        - **For security vulnerabilities, do not use this form** — use the private security advisory link on the previous page (or follow [SECURITY.md](../blob/main/SECURITY.md)).
+        - **Findings _about_ an analyzed agent are not bugs in Praxen.** Those are normal output of running the scanner. Report them to that agent's own maintainer, not here.
+        - A reproducible bug report with concrete inputs (a minimal Worker Remit + a scan target, or a hand-crafted findings JSON) is the fastest path to a fix.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: One or two sentences. The specific behaviour you observed.
+      placeholder: e.g. "render.py crashes with KeyError on findings JSONs that omit `policy_rule_ids`."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      description: One or two sentences. The behaviour you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: How to reproduce
+      description: |
+        Minimal, deterministic steps. Where possible, include the exact command(s), the input file(s) or a small JSON fragment, and the version of Praxen and the runtime. A repro that does not need access to a private agent target is preferred.
+      placeholder: |
+        1. Save the following JSON as `repro.json`: …
+        2. Run `python3 skills/behavior-verifier/render.py --findings repro.json --out-txt /tmp/o.txt`
+        3. Observed: …
+    validations:
+      required: true
+
+  - type: input
+    id: praxen-version
+    attributes:
+      label: Praxen version
+      description: From `claude plugin list`, the GitHub release tag, or the `praxen_version` field of a findings JSON.
+      placeholder: e.g. 0.7.0
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS + Python version + (if relevant) the coding-agent client used to run the skill.
+      placeholder: e.g. macOS 14.4 / Python 3.12.2 / Claude Code 1.0.x
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Anything else — stack traces, screenshots of the rendered report, related findings, prior workarounds you tried.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,18 @@
+# Disable free-form blank issues — every report should go through one of the
+# templates below, or to the security advisory channel.
+blank_issues_enabled: false
+
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/open-ai-security/praxen/security/advisories/new
+    about: >-
+      Do not file a public issue for a security vulnerability. Use GitHub's
+      private security advisory (or follow the steps in SECURITY.md). The
+      maintainers will be notified privately and respond there.
+
+  - name: Question or general discussion
+    url: https://github.com/open-ai-security/praxen/discussions
+    about: >-
+      If GitHub Discussions is enabled on this repo, open-ended questions and
+      design discussion belong there rather than in the issue tracker. (If
+      Discussions is not yet enabled, use the bug or feature template below.)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+name: Feature request / RFE
+description: A new capability, refinement, or behavioural change you would like Praxen to consider.
+title: "RFE: "
+labels: ["enhancement"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. RFEs are most actionable when they describe the *problem* the requester is hitting, not only the proposed solution — that lets us evaluate whether the proposed approach is the right one or whether a different change would solve the same underlying problem.
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: What is the problem you're trying to solve?
+      description: |
+        Concrete and grounded if possible — a real scan you ran, a real report you tried to read, a real Worker Remit you tried to write. What was awkward, missing, or wrong about the current behaviour?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed approach
+      description: |
+        What change would solve it? Be as specific as you can — a schema-field rename, a new SKILL.md step, a new finding tag, a CLI flag for `render.py`, a new section in the HTML report. If you have multiple ideas, pick the one you think is best and mention the others as alternatives below.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other ways this could be done, and why you prefer the proposed approach.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: willing-to-implement
+    attributes:
+      label: Are you willing to send a PR for this?
+      description: Not required — but if you are, say so and one of the maintainers can scope the change with you before you start.
+      options:
+        - "I'd like to send a PR if the maintainers agree on the approach."
+        - "I can review and test a PR but don't plan to write one."
+        - "No — request only."
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Links to relevant findings, related issues / RFEs, prior art in other tools, references in the OWASP or RAISE material.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+<!--
+  Thanks for sending a PR to Praxen.
+
+  Please fill in the sections below. If a section truly does not apply
+  (e.g. a docs-only change has no functional testing), say so explicitly
+  rather than deleting the heading — it signals to reviewers that you
+  considered it.
+
+  By opening this pull request you confirm that your contribution is
+  signed off under the Developer Certificate of Origin (`git commit -s`).
+  CI enforces this; unsigned commits will fail.
+-->
+
+## Summary
+
+<!-- What does this PR change? One or two sentences for the change, plus a
+sentence on *why* it's needed (motivating problem, linked issue/RFE, field
+report, etc.). Link related issues with `Closes #N` / `Refs #N`. -->
+
+## Testing
+
+<!-- How did you verify the change?
+  - `python3 tests/render/test_render.py` should be green; paste the
+    one-line summary (`N passed, 0 failed`).
+  - For changes to the SKILL prompt, the renderer, the schema, or the
+    JSON template, describe any baselines or fixtures you re-rendered
+    and how you confirmed they are correct.
+  - For docs-only changes, "n/a — docs only; rendered locally" is fine. -->
+
+## Notes for reviewers
+
+<!-- Anything reviewers should look at first, design choices worth
+flagging, follow-up work intentionally deferred. Optional. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,7 +11,7 @@ This applies to every project space — issues, pull requests, code reviews, dis
 
 ## Reporting
 
-If you experience or witness conduct that you believe violates the Contributor Covenant, please report it privately to the project maintainers at **steve.wilson@exabeam.com**. Include enough context for the maintainers to understand what happened, when, where, and who was involved. Reports are read and handled by the project maintainers and treated as confidential.
+If you experience or witness conduct that you believe violates the Contributor Covenant, please report it privately to the project maintainers at **open-ai-security@exabeam.com**. Include enough context for the maintainers to understand what happened, when, where, and who was involved. Reports are read and handled by the project maintainers and treated as confidential.
 
 You may also use GitHub's standard reporting tools (block, report content) for in-product behaviour; the maintainer email is the channel for cases that need a substantive maintainer response.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,26 @@
+<!--
+  Copyright 2026 Exabeam, Inc.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Code of Conduct
+
+The Praxen project adopts the **[Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)** as its code of conduct. The full text is the canonical source; this file states only the project-specific reporting and enforcement details required by the Covenant.
+
+This applies to every project space — issues, pull requests, code reviews, discussions, and any other contact made in a Praxen context, on or off GitHub.
+
+## Reporting
+
+If you experience or witness conduct that you believe violates the Contributor Covenant, please report it privately to the project maintainers at **steve.wilson@exabeam.com**. Include enough context for the maintainers to understand what happened, when, where, and who was involved. Reports are read and handled by the project maintainers and treated as confidential.
+
+You may also use GitHub's standard reporting tools (block, report content) for in-product behaviour; the maintainer email is the channel for cases that need a substantive maintainer response.
+
+## Enforcement
+
+The project maintainers are responsible for clarifying the standards of acceptable behaviour, investigating reports, and deciding on a response. Responses follow the **enforcement guidelines** of the Contributor Covenant ([§4 of the linked document](https://www.contributor-covenant.org/version/2/1/code_of_conduct/#enforcement-guidelines)), which describe a graduated set of consequences proportionate to the severity and pattern of conduct.
+
+Maintainers who do not follow or enforce the Code in good faith may face temporary or permanent removal from project responsibilities, at the discretion of the other maintainers.
+
+## Acknowledgement
+
+This document is © 2026 Exabeam, Inc., licensed Apache-2.0. The Contributor Covenant itself is published by its authors under a Creative Commons Attribution 4.0 International license.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,7 @@ Use GitHub's private security advisory:
 
 GitHub will create a private advisory thread between you and the project maintainers. We will respond there.
 
-If GitHub Security Advisories are unavailable to you for any reason, email **steve.wilson@exabeam.com** with the subject line **`Praxen security report`** and the same level of detail.
+If GitHub Security Advisories are unavailable to you for any reason, email **open-ai-security@exabeam.com** with the subject line **`Praxen security report`** and the same level of detail.
 
 ## What to expect
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+<!--
+  Copyright 2026 Exabeam, Inc.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Security Policy
+
+Praxen is a security tool. We take vulnerabilities in Praxen itself seriously. This document describes how to report one privately, what is in scope, and what to expect after you report.
+
+## Scope
+
+**In scope** — vulnerabilities in Praxen itself:
+
+- The `behavior-verifier` skill (the prompt and step graph in `skills/behavior-verifier/SKILL.md`).
+- The deterministic renderer (`skills/behavior-verifier/render.py`) and report template (`report_template.html`).
+- The findings-JSON schema validator (`skills/behavior-verifier/schema.py`, `findings.schema.json`).
+- The plugin manifest (`.claude-plugin/plugin.json`, `marketplace.json`).
+- The build (`build.sh`) and release (`.github/workflows/release.yml`) pipelines, and the published `praxen-X.Y.Z.zip` artifacts.
+
+Examples of in-scope issues: an injection in a finding's `evidence.snippet` that escapes the HTML escaper and executes script in the rendered report; a path-traversal in `render.py` that lets a crafted findings JSON write outside the output directory; a tampered release artifact.
+
+**Out of scope** — findings *about* the agents Praxen analyses. If you run Praxen against an AI agent and Praxen reports a finding against that agent, that is normal output of the tool, not a vulnerability in Praxen. Please report those to the agent's own maintainer, not here.
+
+## Reporting a vulnerability
+
+**Do not file a public GitHub issue for a security vulnerability.** Public issues are indexed and broadcast immediately; that is the wrong channel for an unpatched defect.
+
+Use GitHub's private security advisory:
+
+1. Go to the [Security tab](https://github.com/open-ai-security/praxen/security) on this repository.
+2. Click **Report a vulnerability**.
+3. Fill in the form. Include enough detail to reproduce — a minimal Praxen input, the observed output, and what you expected to differ. Attach the crafted findings JSON, remit, or repro script if applicable.
+
+GitHub will create a private advisory thread between you and the project maintainers. We will respond there.
+
+If GitHub Security Advisories are unavailable to you for any reason, email **steve.wilson@exabeam.com** with the subject line **`Praxen security report`** and the same level of detail.
+
+## What to expect
+
+- **Initial acknowledgement:** within 3 business days of your report.
+- **First substantive reply** (we understand the issue, we agree on scope and severity, here is the plan): within 10 business days.
+- **Fix timeline:** depends on severity and complexity. Critical issues are prioritised; expect a fix in the next release, not the next minor cycle.
+- **Coordinated disclosure:** we prefer to ship the fix in a tagged release, publish a [GitHub Security Advisory](https://github.com/open-ai-security/praxen/security/advisories) (with credit to you unless you ask otherwise), and request a CVE if the issue warrants one. We will coordinate the public-disclosure timing with you.
+
+If you do not hear back from us within the windows above, please nudge the thread or escalate via the email address above.
+
+## Supported versions
+
+Security fixes ship in the **latest** released `0.x` line. Praxen is pre-`1.0` and there is no LTS branch; please upgrade to the latest tagged release before reporting.
+
+| Version | Receiving security fixes |
+|---|---|
+| `0.7.x` | ✓ Yes — current release line |
+| `0.6.x` and earlier (under the former name `Praxa`, at `Exabeam/deckard`) | No — superseded by the rename, not maintained |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,7 @@ If GitHub Security Advisories are unavailable to you for any reason, email **ste
 
 - **Initial acknowledgement:** within 3 business days of your report.
 - **First substantive reply** (we understand the issue, we agree on scope and severity, here is the plan): within 10 business days.
-- **Fix timeline:** depends on severity and complexity. Critical issues are prioritised; expect a fix in the next release, not the next minor cycle.
+- **Fix timeline:** depends on severity and complexity. Critical issues are prioritised; expect a fix in an immediate patch release, rather than waiting for the next scheduled minor release.
 - **Coordinated disclosure:** we prefer to ship the fix in a tagged release, publish a [GitHub Security Advisory](https://github.com/open-ai-security/praxen/security/advisories) (with credit to you unless you ask otherwise), and request a CVE if the issue warrants one. We will coordinate the public-disclosure timing with you.
 
 If you do not hear back from us within the windows above, please nudge the thread or escalate via the email address above.


### PR DESCRIPTION
T1 polish for the public soft launch. Six new files, no code/behaviour/schema changes — but every one of them is something a visitor expects to find at the top level of a serious public repo.

## What's in here

- **`SECURITY.md`** — private disclosure via GitHub Security Advisory (and a fallback email). Scope is explicitly *Praxen itself*, not findings about analysed agents (a category mismatch we want to head off). Supported-versions table covers `0.7.x`; the `0.6.x` line under the former `Praxa` name is not maintained.
- **`CODE_OF_CONDUCT.md`** — adopts Contributor Covenant 2.1 *by reference*; only the project-specific reporting contact and enforcement procedure live in this file. Keeps the document short, maintainable, and aligned with the canonical text.
- **`.github/ISSUE_TEMPLATE/config.yml`** — disables blank issues, adds two contact links (private security-advisory + Discussions).
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — YAML form: what happened / expected / repro / Praxen version / environment. Explicitly calls out the two common not-bugs: security reports (use the advisory channel) and findings about analysed agents (those go to the agent's own maintainer).
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — RFE form that asks for the *problem* first and the proposal second, plus a willing-to-implement dropdown.
- **`.github/pull_request_template.md`** — Summary / Testing / Notes; DCO reminder in the leading comment.

## Pre-requisite: enable Private Security Advisories in repo settings

For `SECURITY.md`'s "Report a vulnerability" link to work, **GitHub's private security advisory feature needs to be enabled** on the repo:

> Settings → Code security → "Private vulnerability reporting" → **Enable**

This is a one-click setting; not blocking the merge, but the link will 404 until it's flipped. Worth doing the moment this lands.

## Out of this PR

The `graphics/` folder Steve added (banner + Praxy poses) is deliberately not staged here — those go in PR B (the README polish) where they actually get used.

## Tests

`python3 tests/render/test_render.py` → **109 passed, 0 failed**. Pure-docs change.