### PR TITLE
ci: Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# Dependabot keeps the GitHub Actions in .github/workflows/ current.
+# Praxen's runtime is stdlib-only Python — there is no language ecosystem
+# (pip / npm / go modules / etc.) for Dependabot to track. The only thing
+# this repo pulls from a registry is GitHub Actions, so that is the only
+# ecosystem configured here. If we ever take a Python (or other) runtime
+# dependency, add a second update block.
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      # Bundle minor + patch updates into one PR per week; majors stay
+      # separate so a breaking-change review isn't lost in the noise.
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
T2 polish — keep the actions in `.github/workflows/` current.

## What this does

Adds `.github/dependabot.yml` with one update block for the `github-actions` ecosystem:
- **Weekly schedule** (Monday 9:00 PT) — low cadence; Praxen has only two action versions to track (`actions/checkout@v5`, `actions/setup-python@v6`).
- **Grouped minor + patch updates** — one PR per week instead of one per bump. Majors stay separate so a breaking-change review isn't bundled with routine version bumps.
- **Labels**: `dependencies`, `github-actions` (Dependabot creates them if missing).
- **PR limit: 5** open at once — sane ceiling.
- **Commit prefix: `ci`** — matches the existing convention.

## Why only GitHub Actions

Praxen's runtime is **stdlib-only Python**. No `pip` / `npm` / module-cache dependencies exist for Dependabot to track. If we ever take a runtime dependency (deferred per the design notes), add a second `updates:` block then.

## Tests

`python3 tests/render/test_render.py` → **109 passed, 0 failed** (docs/config-only change, no source touched).