### PR TITLE
ci: auto-merge Dependabot patch/minor PRs; flag majors for review

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,64 @@
+# Copyright 2026 Exabeam, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Enables GitHub's native auto-merge on Dependabot patch- and minor-version
+# update PRs. Major updates are deliberately left alone — they're more likely
+# to introduce breaking changes and warrant a human glance at the upstream
+# release notes before merging.
+#
+# Why this exists: gemini-code-assist (our review bot) skips bot-authored PRs
+# by policy, so Dependabot PRs never receive a review and would otherwise
+# block on the project's "Gemini review + Steve approval" merge gate forever.
+# Routine patch/minor bumps are exactly the kind of low-risk change that
+# should ship on green CI alone.
+#
+# Mechanism: this fires on `pull_request_target` (which runs with the base
+# branch's secrets and the GITHUB_TOKEN's default repository write scopes —
+# safer than `pull_request` for actions that need write access). The
+# `dependabot/fetch-metadata` action parses the Dependabot PR body for the
+# `update-type` semver classification; only patch and minor pass the filter.
+# `gh pr merge --auto --squash` enables GitHub's native auto-merge, which
+# holds the PR until every required status check goes green, then squashes
+# (matching the repo's squash-only policy).
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # Only act on PRs Dependabot opened. A non-bot author with the literal
+    # string "dependabot[bot]" as their username is impossible — that suffix
+    # is reserved for GitHub Apps' installation actors.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge (patch / minor only)
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"
+
+      - name: Note that majors are left for a human
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "$PR_URL" --body \
+            "Auto-merge skipped: this is a **major-version** update. \
+            A human reviewer should glance at the upstream release notes \
+            before merging. (Patch and minor updates auto-merge once CI \
+            is green; see .github/workflows/dependabot-auto-merge.yml.)"

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,11 @@ praxen-*.zip
 
 # Claude Code harness internals
 .claude/
+
+# Praxen analysis output (per PRAXEN_SPEC.md — reports go to ./reports/ by default)
+reports/
+
+# Python bytecode (build.sh strips these from the dist zip; this keeps them out
+# of the working-tree status too when contributors run the suite locally)
+__pycache__/
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ praxen-*.zip
 
 # Scan-agent scratch (subagent runs that fell back off /tmp into the repo)
 .praxen-*
+
+# Claude Code harness internals
+.claude/


### PR DESCRIPTION
Fixes the "Dependabot PRs never get reviewed and accumulate" problem we hit on PR #14. gemini-code-assist skips bot-authored PRs by policy — so under the project's "Gemini review + Steve approval" merge gate, every Dependabot PR would sit forever. This is Option C from the design discussion: hands-off auto-merge for the routine bumps, human glance for the riskier ones.

## Mechanism

- **Fires on `pull_request_target`** — runs in the base-branch context with the default `GITHUB_TOKEN`'s write scope (safer than `pull_request` for actions that need to merge).
- **`dependabot/fetch-metadata@v2`** parses the Dependabot PR body for the `update-type` semver classification (`version-update:semver-patch` / `semver-minor` / `semver-major`).
- **Patch and minor:** `gh pr merge --auto --squash` enables GitHub's native auto-merge — the PR waits for every required status check to go green, then squashes (matching the repo's squash-only policy).
- **Major:** posts a comment explaining auto-merge was skipped, leaves the PR for a human reviewer. Majors are more likely to ship breaking changes worth eyeballing the upstream release notes for.

## Safety

The job's `if:` filters to `github.event.pull_request.user.login == 'dependabot[bot]'`. The `[bot]` suffix is reserved for GitHub Apps' installation actors and cannot be spoofed by ordinary user accounts (same reasoning as the DCO bot-exemption in #15).

`pull_request_target` runs the workflow from the **base branch** (after merge of this PR, that means `main`), not from the PR's head — so a hostile PR can't modify the auto-merge workflow to attack itself.

## Effect on PR #14

PR #14 (`actions/checkout` v5→v6, a major bump) **will not** auto-merge under this workflow even after rebase — it's a major and falls through to the human-review path. Worth noting because that PR is currently sitting waiting for your call; this workflow doesn't unblock it. (You can still merge it manually.)

## Tests

`python3 tests/render/test_render.py` → **109 passed, 0 failed**. YAML parses (`python3 -c "yaml.safe_load(...)"` confirmed).

This workflow only affects **future** Dependabot PRs and on-rebase events for currently-open ones.