### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Open AI Security's Claude Code plugin marketplace. Currently publishes Praxen.",
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "plugins": [
     {
       "name": "praxen",
       "source": "./",
       "description": "Praxen — agent behavior verifier. Compares an agent's declared policy against the available evidence (source, deployment state, or behavioral artifacts); reports where observed behavior diverges from declared intent.",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "Apache-2.0",
       "keywords": [
         "agent-behavior-verifier",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "praxen",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Praxen — agent behavior verifier. Compares an AI agent's declared policy (Worker Remit) against the available evidence — source code, live deployment state, or behavioral artifacts — and reports where observed behavior diverges from declared intent. Make sure your agent does its job — and only its job.",
   "author": {
     "name": "Exabeam",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ All notable changes to Praxen will be recorded here. Format roughly follows [Kee
 
 ---
 
-## [Unreleased]
+## [0.7.1] — 2026-05-22
 
-**Two batches of operator field feedback rolled in pre-release.** No scan logic, schema shape, or scoring behaviour changed — all changes are documentation and a small renderer tweak. The eleven regression baselines re-render byte-identical from their JSON (the renderer change is stdout-only).
+**Three batches of operator field feedback rolled in as a single patch release.** No scan logic, schema shape, or scoring behaviour changed — all changes are documentation and a small renderer tweak. The eleven regression baselines re-render byte-identical from their JSON (the renderer change is stdout-only). Patches against `0.7.0`; same plugin name, same install path, same canonical findings JSON.
 
 ### Added
 - **`SKILL.md` opens with a quick-start (TL;DR) block** — what the skill does, the two inputs it needs (Worker Remit + workspace path), what it writes (three files in `./reports/` plus the Step 9.9 checkpoint), and a one-paragraph map of the 12-step pipeline. Sits above the existing intro so operators don't need to read the 700-line procedure before understanding what they're invoking. Reported by the Lobot field tester.

--- a/PRAXEN_SPEC.md
+++ b/PRAXEN_SPEC.md
@@ -5,7 +5,7 @@
 
 # Praxen — Specification
 
-**Version:** 0.7.0
+**Version:** 0.7.1
 **Status:** Internal release
 **Tagline:** *Make sure your agent does its job — and only its job.*
 
@@ -258,7 +258,7 @@ Every analysis emits one JSON file — the **canonical, complete record** of the
 ```json
 {
   "schema_version": "2.0",
-  "praxen_version": "0.7.0",
+  "praxen_version": "0.7.1",
   "scan": {
     "agent": "<agent name>",
     "agent_slug": "<agent-slug>",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 # Praxen
-**agent behavior verifier · Version 0.7.0**
+**agent behavior verifier · Version 0.7.1**
 
 [![CI](https://github.com/open-ai-security/praxen/actions/workflows/ci.yml/badge.svg)](https://github.com/open-ai-security/praxen/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/v/release/open-ai-security/praxen?sort=semver)](https://github.com/open-ai-security/praxen/releases)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,7 +26,7 @@ This is the recommended path for Claude Code users. From your terminal:
 ```bash
 claude plugin marketplace add open-ai-security/praxen
 claude plugin install praxen@open-ai-security
-claude plugin list      # confirm: praxen@open-ai-security, enabled, v0.7.0+
+claude plugin list      # confirm: praxen@open-ai-security, enabled, v0.7.1+
 ```
 
 The skill registers as `behavior-verifier`. The in-session equivalents — `/plugin marketplace add …`, `/plugin install …`, `/plugin list` — do exactly the same thing; if you install from within a Claude Code session, run `/reload-plugins` (or restart) to activate the skill. Prefer the terminal form when scripting: `claude plugin …` is argument-driven and runs the same way on every interface, whereas in-session slash commands occasionally fall through and get sent as ordinary chat messages.
@@ -38,9 +38,9 @@ The skill registers as `behavior-verifier`. The in-session equivalents — `/plu
 If you can't or don't want to use the plugin marketplace flow, unzip the release archive somewhere your coding agent can see it. There's no install step.
 
 ```bash
-curl -L -o praxen-0.7.0.zip <release-URL>
-unzip praxen-0.7.0.zip
-cd praxen-0.7.0
+curl -L -o praxen-0.7.1.zip <release-URL>
+unzip praxen-0.7.1.zip
+cd praxen-0.7.1
 ```
 
 Then point your coding agent at `skills/behavior-verifier/SKILL.md` when running an analysis. See [Usage](usage.md).
@@ -55,7 +55,7 @@ Run:
 claude plugin list
 ```
 
-If `praxen@open-ai-security` appears at `v0.7.0` or later with `enabled`, the marketplace install is working. From within a Claude Code session, the same plugin shows up under `/plugin list`, and the skill is invocable as `behavior-verifier`.
+If `praxen@open-ai-security` appears at `v0.7.1` or later with `enabled`, the marketplace install is working. From within a Claude Code session, the same plugin shows up under `/plugin list`, and the skill is invocable as `behavior-verifier`.
 
 For an end-to-end first run that actually exercises the analysis pipeline — Worker Remit + agent source → HTML / JSON / TXT report — see [Quickstart](quickstart.md). It walks through scanning the bundled `finbot` example in about five minutes.
 

--- a/skills/behavior-verifier/SKILL.md
+++ b/skills/behavior-verifier/SKILL.md
@@ -751,7 +751,7 @@ This file is the **complete behavioral record**: everything the HTML report show
 ```json
 {
   "schema_version": "2.0",
-  "praxen_version": "0.7.0",
+  "praxen_version": "0.7.1",
   "scan": {
     "agent": "<agent name>",
     "agent_slug": "<agent-slug>",


### PR DESCRIPTION
## Summary

Patch release rolling up three batches of operator field feedback already merged on main since `0.7.0`:

| PR | Source | Items |
|---|---|---|
| [#18](https://github.com/open-ai-security/praxen/pull/18) | Lobot field tester | 5: quick-start TL;DR, renderer summary line, schema-mirrored draft manifest, `stat_counts` Counter-gotcha, multi-OWASP primary-tag rule |
| [#19](https://github.com/open-ai-security/praxen/pull/19) | Ambient-expense field tester | 8: remit-authoring trigger + pre-flight, TOC, OWASP tag-label table, line-range evidence, verified-rule consistency, indirect-link guidance, Evidence Discipline scope, post-compaction 9.9 half-gate |
| [#20](https://github.com/open-ai-security/praxen/pull/20) | yaah pre-integration #2 subagent | 1: MCP-tagging threshold clarification (procedural discriminator) |

**No scan logic, schema shape, or scoring behaviour changed.** All eleven regression baselines re-render byte-identical from their JSONs. Patches against `0.7.0`; same plugin name, same install path, same canonical findings JSON.

## Version pins (10 occurrences across 7 files)

| File | What |
|---|---|
| `CHANGELOG.md` | `[Unreleased]` → `[0.7.1] — 2026-05-22`; intro reworded to "Three batches… rolled in as a single patch release" |
| `.claude-plugin/plugin.json` | `version` |
| `.claude-plugin/marketplace.json` | Top-level `version` + plugin-entry `version` |
| `skills/behavior-verifier/SKILL.md` | `praxen_version` literal in the Step 10 JSON template |
| `README.md` | Header version line |
| `PRAXEN_SPEC.md` | `**Version:**` field + `praxen_version` in the JSON example (the release workflow's tag-verify step reads this) |
| `docs/installation.md` | Three references: `v0.7.0+` plugin-list comment, `praxen-0.7.0.zip` in unzip example, `v0.7.0 or later` note in verifying-the-install |

## Left alone (correctly historical)

- All `CHANGELOG.md` references to the 0.7.0 release / rename / artifact / repo move
- `tests/baselines/v0.7.0-sequential/` directory name — the v0.7.0 baselines remain the comparison point for 0.7.x patches because no scan-logic changes shipped in this release
- `tests/README.md` references to `v0.7.0-sequential/`
- `findings.schema.json`'s "Praxen 0.7.0+" lineage description — the schema is unchanged across 0.7.0 / 0.7.1, so "0.7.0+" remains accurate

## Testing

- `tests/render/test_render.py`: **110 passed, 0 failed**
- All eleven `v0.7.0-sequential/` baselines re-render byte-identical
- Three pre-integration scan rounds already validated the underlying behaviour (PR #18 + #19 used finbot + yaah; PR #20 used yaah focused on the MCP-tagging change)

## After this merges

1. **Plugin install smoke check** per the standing test-before-release rule — Steve runs from his terminal:
   ```
   claude plugin marketplace add open-ai-security/praxen
   claude plugin install praxen@open-ai-security
   claude plugin list   # should show praxen@open-ai-security at 0.7.1, enabled
   ```
2. **Tag and release**:
   ```
   git tag v0.7.1 && git push origin v0.7.1
   ```
   The `release.yml` workflow fires on the `v*` tag, validates the tag matches `PRAXEN_SPEC.md`'s `**Version:**` line, builds `praxen-0.7.1.zip`, and cuts a GitHub release with the `[0.7.1]` changelog section as the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)