### PR TITLE
docs: adopt dev/main branching workflow for pre-release stability

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,10 @@
 <!--
   Thanks for sending a PR to Praxen.
 
+  Base branch: target `dev`, not `main`. `main` is the release branch and only
+  receives release PRs. If GitHub defaulted the base to `main`, switch it to
+  `dev` (unless you are specifically cutting a release).
+
   Please fill in the sections below. If a section truly does not apply
   (e.g. a docs-only change has no functional testing), say so explicitly
   rather than deleting the heading — it signals to reviewers that you

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,8 @@ By making a contribution to this project, I certify that:
 ## Branching
 
 Branch from and target **`dev`**, not `main`. `main` is the release branch that
-downstream teams install from via the Claude Code plugin marketplace — a fresh
-`plugin marketplace add` pulls `main` at HEAD — so it only receives release PRs
+downstream teams install via the Claude Code plugin marketplace — a fresh
+`/plugin marketplace add` pulls `main` at HEAD — so it only receives release PRs
 at version-bump time. Everyday work lands on `dev` first and reaches `main` as
 part of a deliberate, re-verified release.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,17 @@ By making a contribution to this project, I certify that:
     involved.
 ```
 
+## Branching
+
+Branch from and target **`dev`**, not `main`. `main` is the release branch that
+downstream teams install from via the Claude Code plugin marketplace — a fresh
+`plugin marketplace add` pulls `main` at HEAD — so it only receives release PRs
+at version-bump time. Everyday work lands on `dev` first and reaches `main` as
+part of a deliberate, re-verified release.
+
+When you open a PR, GitHub pre-selects the base branch as the repository default
+(`main`); switch it to `dev` unless you are specifically cutting a release.
+
 ## Before you open a PR
 
 - Run the test suite: `python3 tests/render/test_render.py` — it should report all checks passing.


### PR DESCRIPTION
## Summary

Establishes the `dev`/`main` split we discussed for pre-release stability. `main` becomes the release channel that downstream teams install from; `dev` becomes the integration branch where everyday work lands first.

**Why:** a fresh `claude plugin marketplace add open-ai-security/praxen` (no `@ref`) clones the repo's **default branch at HEAD** — that's what every new external team gets. The `version` field only gates *updates* to already-installed plugins, not fresh installs. So whatever sits on the default branch is our public surface, and `main` must stay both the default branch and frozen-between-releases.

This is the bootstrapping PR for that workflow, so it targets `main` directly. After it merges, `dev` is created from the updated `main` (carrying this guidance), and branch protection goes on `main`.

Changes:
- **CONTRIBUTING.md** — new Branching section directing contributor PRs at `dev`, with a note that GitHub will pre-select `main` and they should switch it.
- **pull_request_template.md** — base-branch reminder in the header comment.
- **ci.yml** — `push` trigger now covers `dev` as well as `main` (the `pull_request` trigger was already unfiltered, so PRs into `dev` were already covered; this just adds CI on direct pushes to `dev`).

## Testing

n/a — docs + CI-trigger only; no functional change to the tool. `tests/render/test_render.py` is unaffected. CI will exercise the workflow file on this PR.

## Notes for reviewers

- Not adding a CHANGELOG entry: this is a contributor-workflow change, not a user-facing change to the tool.
- The dev branch creation + branch protection on `main` are follow-on admin steps after this merges, not part of the diff.
- Standing gate applies: holding for Gemini review + explicit merge approval before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)