### PR TITLE
chore(ci): enforce dev-not-behind-main + document the realign rule

### DIFF
--- a/.github/workflows/branch-drift.yml
+++ b/.github/workflows/branch-drift.yml
@@ -1,0 +1,44 @@
+# Copyright 2026 Exabeam, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fails if `dev` is on an OLDER release than `main` — i.e. a release (or hotfix)
+# landed on `main` and was never back-merged into `dev`. See CONTRIBUTING.md,
+# "Keeping `dev` in sync with `main`".
+#
+# This deliberately checks the release VERSION, not a raw `git diff`: `dev` is
+# expected to be *ahead* of `main` between releases (unreleased feature work),
+# and squash-merging means the two branches never share commit SHAs. The only
+# real failure is `dev` sitting on an older version than `main`.
+name: Branch drift
+
+on:
+  schedule:
+    - cron: "17 14 * * 1-5" # weekday mid-day UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  dev-not-behind-main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: dev must not be on an older release than main
+        run: |
+          git fetch -q origin main dev
+          ver() { git show "origin/$1:.claude-plugin/plugin.json" \
+            | sed -nE 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -1; }
+          dev_v="$(ver dev)"; main_v="$(ver main)"
+          echo "dev=$dev_v  main=$main_v"
+          if [ -z "$dev_v" ] || [ -z "$main_v" ]; then
+            echo "::error::could not read plugin.json version on dev and/or main"; exit 1
+          fi
+          newest="$(printf '%s\n%s\n' "$dev_v" "$main_v" | sort -V | tail -1)"
+          if [ "$dev_v" != "$main_v" ] && [ "$newest" = "$main_v" ]; then
+            echo "::error::dev ($dev_v) is behind main ($main_v) — a release landed on main without a back-merge. Open chore/sync-dev-with-main (git merge origin/main into dev, resolve in favour of main). See CONTRIBUTING.md, 'Keeping dev in sync with main'."
+            exit 1
+          fi
+          echo "OK: dev ($dev_v) is not behind main ($main_v)."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ The standing rule (maintainers — `dev` is unprotected):
   soon as the release squash lands on `main` and the `vX.Y.Z` tag is cut, run —
   **before any new feature work** —
   ```
-  git checkout dev && git reset --hard origin/main && git push --force-with-lease origin dev
+  git fetch origin && git checkout dev && git reset --hard origin/main && git push --force-with-lease origin dev
   ```
   `dev` restarts cleanly from the released commit, so it can never sit behind
   `main`. This step has existed since 0.7.2; skipping it after 0.7.5 is how `dev`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,39 @@ part of a deliberate, re-verified release.
 When you open a PR, GitHub pre-selects the base branch as the repository default
 (`main`); switch it to `dev` unless you are specifically cutting a release.
 
+### Keeping `dev` in sync with `main`
+
+`main` and `dev` **diverge by construction**: a release is squash-merged from a
+`release/x.y` branch into `main`, which creates a new commit `dev` doesn't share.
+If release-only content — the version bump, the `CHANGELOG` entry, the frozen
+baseline, the spec edits — is authored on the release branch and never returns,
+`dev` silently falls *behind* `main`, and every release widens the gap. (This is
+how `dev` ended up two releases behind through 0.7.7.)
+
+The standing rule (maintainers — `dev` is unprotected):
+
+- **Realign `dev` to `main` immediately after every release (and any hotfix).** As
+  soon as the release squash lands on `main` and the `vX.Y.Z` tag is cut, run —
+  **before any new feature work** —
+  ```
+  git checkout dev && git reset --hard origin/main && git push --force-with-lease origin dev
+  ```
+  `dev` restarts cleanly from the released commit, so it can never sit behind
+  `main`. This step has existed since 0.7.2; skipping it after 0.7.5 is how `dev`
+  ended up two releases behind through 0.7.7.
+- **If `dev` has *already* diverged with unreleased work** (so a hard reset would
+  discard it), don't reset — recover with a `chore/sync-dev-with-main` PR instead:
+  `git merge origin/main` into `dev`, resolving squash conflicts in favour of
+  `main` (the content-newer side). This is how the 0.7.7 gap was reconciled.
+- **Optionally, finalize releases *through* `dev`** (author the version bump,
+  `CHANGELOG`, and baseline freeze as PRs into `dev`, or merge the `release/x.y`
+  branch back into `dev`) so `main` never holds content that isn't already on
+  `dev` — which makes the realign a clean no-op.
+
+A scheduled CI check (`.github/workflows/branch-drift.yml`) fails if `dev` is ever
+on an older release than `main`, so a skipped realign is caught the next day
+instead of accumulating across releases.
+
 ## Before you open a PR
 
 - Run the test suite: `python3 tests/render/test_render.py` — it should report all checks passing.


### PR DESCRIPTION
## Enforce "`dev` not behind `main`" + document the realign rule

**Answers "how did `dev` get behind `main`, and what stops it recurring?"**

### What happened
The post-release realign of `dev` to `main` (`git reset --hard origin/main`) has been the documented practice since 0.7.2 — but it's a **manual step, and it was skipped after 0.7.6 and 0.7.7**. Because releases are squash-merged onto `main` from a `release/x.y` branch (cut from `dev`), the release-finalization content (version bump, CHANGELOG, baseline freeze, spec edits) landed only on `main` and never returned to `dev`. Two missed realigns = `dev` two releases behind (`0.7.5`-content while `main` shipped `0.7.7`). Surfaced when trying to PR the `v0.7.7-claude48` rebaseline into `dev`; reconciled via the #49 back-merge.

It wasn't a missing rule — it was a missing **safety net**. This PR adds one.

### Changes
- **`.github/workflows/branch-drift.yml`** — scheduled (weekdays) + `workflow_dispatch` check that **fails when `dev`'s `plugin.json` release version is older than `main`'s**. Version-aware on purpose: a raw `git diff main dev` would false-positive constantly, because `dev` is *supposed* to be ahead of `main` between releases and squash-merging means the two branches never share commit SHAs. The only real failure mode is `dev` sitting on an older release — which is exactly what this checks. Logic verified locally (semver-aware via `sort -V`; current `dev`==`main`==`0.7.7` → passes; a simulated `0.7.7` vs `0.7.8` → fails).
- **`CONTRIBUTING.md` → "Keeping `dev` in sync with `main`"** — documents the divergence mechanism and three things: the post-release `reset --hard` realign (primary), the `chore/sync-dev-with-main` back-merge (recovery once `dev` has diverged, as in #49), and the optional "finalize releases through `dev`" structural fix that makes the realign a no-op.

### Note
The drift workflow is `schedule` + `workflow_dispatch` only, so it doesn't gate this PR; happy to `workflow_dispatch` it once merged to confirm a green run on the real branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
