### PR TITLE
docs: editorial scrub — de-duplicate, give each set-piece one owner

### DIFF
--- a/docs/RAISE.md
+++ b/docs/RAISE.md
@@ -29,7 +29,7 @@ Are the data sources feeding the agent trustworthy and appropriate? Does externa
 
 ### Implement Zero Trust
 
-Does every action the agent takes go through appropriate validation and approval? Are inputs checked? Are outputs filtered? Are destructive capabilities gated? This category carries **25% weight** — double the others — because it covers the broadest attack surface and the most immediately exploitable gaps.
+Does every action the agent takes go through appropriate validation and approval? Are inputs checked? Are outputs filtered? Are destructive capabilities gated? This category carries the heaviest weight in the overall score (see [Weighted Overall Score](#weighted-overall-score) below).
 
 **Scanner looks for:** input validation, output filtering, tool-call approval gates, exec-capability restriction, least-privilege credentials, code-level enforcement of policy rules.
 
@@ -73,16 +73,6 @@ Most production AI agents today score between **Ad hoc (1)** and **Established (
 ## Weighted Overall Score
 
 Each category contributes to the overall score with a fixed weight. **Implement Zero Trust counts double** because it covers the broadest attack surface and the most immediately exploitable gaps; the other five each carry 15%.
-
-```mermaid
-pie title "RAISE category weights (Σ = 100%)"
-  "Implement Zero Trust (25%)" : 25
-  "Limit Your Domain (15%)" : 15
-  "Balance Your Knowledge Base (15%)" : 15
-  "Manage Your Supply Chain (15%)" : 15
-  "Build an AI Red Team (15%)" : 15
-  "Monitor Continuously (15%)" : 15
-```
 
 | Category | Weight | Why |
 |---|:-:|---|

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,7 @@ Praxen ships as a Claude Code plugin. You can install it through the plugin mark
 ## Prerequisites
 
 - **A coding agent** capable of tool use and multi-step instruction-following. Praxen is tested against [Claude Code](https://docs.claude.com/en/docs/claude-code/overview); other coding agents that can read a skill markdown file and call tools (Read, Grep, Glob, Bash, Write) should also work.
-- **Python 3.9 or newer on the PATH.** Praxen's report renderer (`render.py`, bundled with the skill) is plain Python 3 — standard library only, nothing to `pip install`. 3.9 is the macOS Command Line Tools system Python (Ventura / Sonoma / Sequoia), so on macOS there's typically nothing to install. On Windows, `py -3` works. If `python3` isn't found, the renderer step falls back to `python`. (3.8 was supported up to v0.2.0 and dropped at v0.3.0 — EOL since 2024-10-07.)
+- **Python 3.9 or newer on the PATH.** Praxen's report renderer (`render.py`, bundled with the skill) is plain Python 3 — standard library only, nothing to `pip install`. 3.9 is the macOS Command Line Tools system Python (Ventura / Sonoma / Sequoia), so on macOS there's typically nothing to install. On Windows, `py -3` works. If `python3` isn't found, the renderer step falls back to `python`.
 - **Network access for your coding agent's LLM provider** during analysis. Praxen itself does not phone home, but the LLM calls your coding agent makes during analysis follow whatever provider configuration the agent uses.
 
 That's the entire dependency surface.

--- a/docs/interpreting-reports.md
+++ b/docs/interpreting-reports.md
@@ -170,7 +170,7 @@ Low confidence is valid and expected when the input shape doesn't cover a catego
 | `raise_posture` | `weighted_overall` (the 0.0–5.0 scalar), `weighted_rationale`, and `categories[]` (the six RAISE categories, each with `key`, `name`, `score`, `confidence`, `weight`, `rationale`) |
 | `footer` | `severity_counts` (critical / high / medium / low / info) |
 
-The JSON holds **semantic values, not presentation** — `severity` is `"Critical"`, `status` is `"gap"`; CSS classes and the maturity label are computed by the renderer, not stored. So a consumer that wants the posture number reads `raise_posture.weighted_overall`; one that wants the headline reads `behavior_summary`; no HTML parsing needed. The bundled `schema.py` validator (which `render.py` runs before rendering) enforces the cross-field invariants, so a JSON that exists alongside an HTML report is internally consistent — see [`PRAXEN_SPEC.md`](../PRAXEN_SPEC.md) §6 for the full schema.
+The JSON holds **semantic values, not presentation** — `severity` is `"Critical"`, `status` is `"gap"`; CSS classes and the maturity label are computed by the renderer, not stored. So a consumer that wants the posture number reads `raise_posture.weighted_overall`; one that wants the headline reads `behavior_summary`; no HTML parsing needed. The bundled `schema.py` validator (which `render.py` runs before rendering) enforces the cross-field invariants, so a JSON that exists alongside an HTML report is internally consistent — see [`PRAXEN_SPEC.md` §6](../PRAXEN_SPEC.md#6-canonical-findings-json) for the full schema.
 
 Use the JSON for:
 

--- a/docs/interpreting-reports.md
+++ b/docs/interpreting-reports.md
@@ -22,8 +22,6 @@ flowchart LR
   CJ --> SC
 ```
 
-The split matters in practice: the synthesis is an LLM job (judgement, calibration, prose), the rendering is mechanical (deterministic, no LLM call, byte-identical re-render from the same JSON). The JSON is the *canonical record*; the HTML and TXT are derived views.
-
 This page walks through what each section of the HTML report means, how severities and confidence levels work, how the RAISE maturity score should be read, and what's in the JSON.
 
 ---
@@ -121,7 +119,7 @@ This section contains:
 - **Six per-category cards** (Limit Your Domain, Balance Your Knowledge Base, Implement Zero Trust, Manage Your Supply Chain, Build an AI Red Team, Monitor Continuously) with score, confidence, weight, and rationale
 - **The Maturity Scoring Rubric** — the 0–5 scale with labels and meanings, baked into every report
 
-**This is a maturity model, not a school grade.** A score of 3 / 5 means *Established*, not 60 percent. Most production AI agents today score between *Ad hoc* (1) and *Established* (3). A score of 2.5 places an agent in the *Partial → Established* maturity band — that is accurate reporting of current industry norms, not a failing grade. See [The RAISE Framework](RAISE.md) for the full rubric.
+**This is a maturity model, not a school grade** — a 3 / 5 means *Established*, not 60 percent, and most production AI agents today land between *Ad hoc* (1) and *Established* (3). See [The RAISE Framework](RAISE.md) for the full rubric and how to read a given band.
 
 ### 12. Footer
 
@@ -172,7 +170,7 @@ Low confidence is valid and expected when the input shape doesn't cover a catego
 | `raise_posture` | `weighted_overall` (the 0.0–5.0 scalar), `weighted_rationale`, and `categories[]` (the six RAISE categories, each with `key`, `name`, `score`, `confidence`, `weight`, `rationale`) |
 | `footer` | `severity_counts` (critical / high / medium / low / info) |
 
-The JSON holds **semantic values, not presentation** — `severity` is `"Critical"`, `status` is `"gap"`; CSS classes and the maturity label are computed by the renderer, not stored. So a consumer that wants the posture number reads `raise_posture.weighted_overall`; one that wants the headline reads `behavior_summary`; no HTML parsing needed. The bundled `schema.py` validator (which `render.py` runs before rendering) enforces the cross-field invariants — counts match the arrays, anchors resolve, the six RAISE keys are present, `weighted_overall` equals Σ(score × weight) — so a JSON that exists alongside an HTML report is internally consistent.
+The JSON holds **semantic values, not presentation** — `severity` is `"Critical"`, `status` is `"gap"`; CSS classes and the maturity label are computed by the renderer, not stored. So a consumer that wants the posture number reads `raise_posture.weighted_overall`; one that wants the headline reads `behavior_summary`; no HTML parsing needed. The bundled `schema.py` validator (which `render.py` runs before rendering) enforces the cross-field invariants, so a JSON that exists alongside an HTML report is internally consistent — see [`PRAXEN_SPEC.md`](../PRAXEN_SPEC.md) §6 for the full schema.
 
 Use the JSON for:
 

--- a/docs/owasp.md
+++ b/docs/owasp.md
@@ -11,7 +11,7 @@ Every finding Praxen produces is tagged against industry-standard OWASP framewor
 
 ## OWASP, briefly
 
-The **Open Worldwide Application Security Project** ([owasp.org](https://owasp.org/)) is a non-profit foundation that produces free, community-built security resources — standards, tools, and the famous "Top 10" risk lists. Its material is vendor-neutral, openly licensed (mostly CC BY-SA), and widely treated as a baseline reference in application security. The original *OWASP Top 10* for web applications is the best-known example.
+The **Open Worldwide Application Security Project** ([owasp.org](https://owasp.org/)) is the non-profit foundation behind the vendor-neutral, openly-licensed "Top 10" risk lists that are a baseline reference across application security.
 
 ## OWASP Gen AI Security Project
 
@@ -50,7 +50,7 @@ The risk landscape for any system that puts an LLM in the loop. Each finding Pra
 
 ## OWASP Top 10 for Agentic AI Applications 2026
 
-Risks that emerge once an LLM is wired to tools, memory, other agents, and the ability to act. This is the list that matters most for the kind of OpenClaw-style workers Praxen is built to verify.
+Risks that emerge once an LLM is wired to tools, memory, other agents, and the ability to act. This is the list that matters most for the kind of autonomous, tool-using agents Praxen is built to verify.
 
 | ID | Risk | One-line gloss |
 |---|---|---|

--- a/docs/understanding-variability.md
+++ b/docs/understanding-variability.md
@@ -9,14 +9,14 @@ Run Praxen twice on the *same* agent, with the *same* Worker Remit and the *same
 
 ## Where the variability comes from
 
-A Praxen analysis has two stages, and only one of them varies. **Stage 1 — synthesis** is an LLM job (your coding agent running the skill): reading the code, deciding what is and isn't a finding, judging severity, and assigning the six RAISE category scores are all *acts of judgement*, and the same model won't make every borderline call identically every time — much as two equally-qualified reviewers would write similar-but-not-identical reports. **Stage 2 — rendering (`render.py`)** is deterministic: the same `findings.json` always produces byte-identical HTML/TXT. So all the variability lives in the Stage-1 synthesis, captured in `findings.json`. (See [Interpreting Reports](interpreting-reports.md) for the full two-stage picture and diagram.)
+A Praxen analysis has two stages, and only one of them varies. **Stage 1 — synthesis** is an LLM job (your coding agent running the skill): reading the code, deciding what is and isn't a finding, judging severity, and assigning the six RAISE category scores are all *acts of judgment*, and the same model won't make every borderline call identically every time — much as two equally-qualified reviewers would write similar-but-not-identical reports. **Stage 2 — rendering (`render.py`)** is deterministic: the same `findings.json` always produces byte-identical HTML/TXT. So all the variability lives in the Stage-1 synthesis, captured in `findings.json`. (See [Interpreting Reports](interpreting-reports.md) for the full two-stage picture and diagram.)
 
 ### Two flavours: variance and drift
 
 - **Variance** — run-to-run scatter on a *fixed* model. Re-running the same analysis lands in a slightly different place each time.
 - **Drift** — a *systematic* shift when the underlying model changes (a model upgrade, a different model tier). A newer model may, for example, credit a partially-implemented control slightly more or less generously than the one before it. Drift moves the centre point; variance is the scatter around it.
 
-Both are normal. Both are larger for *judgement-sensitive* targets (see below) and smaller for clear-cut ones.
+Both are normal. Both are larger for *judgment-sensitive* targets (see below) and smaller for clear-cut ones.
 
 ## How much to expect
 
@@ -26,27 +26,27 @@ The stable signal is the **finding set**; the noisy signal is the **exact number
 |---|---|---|
 | **Dominant findings / themes** | **High** | The material findings — the Criticals, the headline divergences — reproduce run to run. If a finding is real, it shows up every time. |
 | **Severity counts** (C/H/M/L/I) | Moderate | Expect a swing of roughly **±2–3 in a bucket** between runs, mostly from Critical↔High reclassification and borderline finding consolidation. |
-| **Weighted RAISE score** | Moderate | Typically within **±0.3** of its centre, occasionally up to **±0.5** for judgement-sensitive targets — usually less than half a maturity-band step. |
+| **Weighted RAISE score** | Moderate | Typically within **±0.3** of its centre, occasionally up to **±0.5** for judgment-sensitive targets — usually less than half a maturity-band step. |
 | **Per-category 0–5 scores** | Lower at the margins | The `0↔1` ("absent vs ad-hoc") and `2↔3` ("partial vs established") boundaries are where most of the wobble lives. |
 | **Rendered HTML / TXT** | Exact | Byte-identical for a given JSON. No variability. |
 | **`R-NN` rule IDs** | Run-local | The rule numbering is re-derived each run; the *same* remit clause can get a different `R-NN` in two runs. Compare by rule **text**, not ID. |
 
 **Judgement-sensitive targets vary more.** Where a target has *operative-but-imperfect controls* — a framework that ships guardrails the example doesn't wire up, a sandbox with permissive defaults, a partial mitigation — the "how much credit does this earn?" call is genuinely ambiguous, and that's where the weighted score moves most between runs. Deliberately-insecure agents (everything missing) and well-engineered agents (controls clearly present and operative) are the *most* reproducible, because there's little to debate. Targets in the messy middle are the least.
 
-**Read the themes, not the decimal.** A weighted score of 1.3 on one run and 1.5 on the next is the *same posture* described with normal judgement scatter. A maturity **label** that changes (e.g. *Ad hoc* ↔ *Partial*) right at a band boundary is the same story — the boundary is a round number, not a cliff. What should *not* change between runs is the set of material findings and the Critical themes; if those move, that's signal, not noise.
+**Read the themes, not the decimal.** A weighted score of 1.3 on one run and 1.5 on the next is the *same posture* described with normal judgment scatter. A maturity **label** that changes (e.g. *Ad hoc* ↔ *Partial*) right at a band boundary is the same story — the boundary is a round number, not a cliff. What should *not* change between runs is the set of material findings and the Critical themes; if those move, that's signal, not noise.
 
 ## Following up with the LLM
 
 Because synthesis is an LLM step, you can interrogate and revise it in conversation — ask the agent to explain a score, re-examine a finding against its evidence, or re-evaluate a category, and it re-emits the findings JSON. That workflow (and why you revise the manifest/JSON rather than the HTML) is covered in [Challenging and Revising Findings](challenging-findings.md).
 
-The move specific to *variability*: **re-run the whole analysis** and see whether a borderline result reproduces. If it holds, it's real; if it swings, the target is judgement-sensitive (above) and worth characterising over several runs — see below.
+The move specific to *variability*: **re-run the whole analysis** and see whether a borderline result reproduces. If it holds, it's real; if it swings, the target is judgment-sensitive (above) and worth characterising over several runs — see below.
 
 ## When stability matters more than runtime
 
 A single run is the right default — it's fast and cheap, and for reading an agent's posture the themes are what matter. But when the *number itself* matters — gating a release, freezing a baseline, comparing before-and-after, or reporting a maturity score to a stakeholder — trade some runtime and token cost for stability:
 
 1. **Run the analysis N times** (3 is a good default) on identical inputs. Keep the Worker Remit and the analyzed scope *byte-identical* across runs so you're measuring synthesis variance, not input differences.
-2. **Aggregate the score** — report the **median (or mean) weighted score**, and note the **range**. A target whose three runs land at 1.3 / 1.4 / 1.3 is well-characterised; one that lands 1.0 / 1.6 / 1.2 is telling you it's judgement-sensitive — report the spread, don't pretend the single number is precise.
+2. **Aggregate the score** — report the **median (or mean) weighted score**, and note the **range**. A target whose three runs land at 1.3 / 1.4 / 1.3 is well-characterised; one that lands 1.0 / 1.6 / 1.2 is telling you it's judgment-sensitive — report the spread, don't pretend the single number is precise.
 3. **Union the findings** — take the set of material findings that appear across runs. A Critical that appears in all three is solid; one that appears in one of three is worth a closer look (often a real edge case, occasionally an over-call) — a good candidate to [follow up with the LLM](#following-up-with-the-llm).
 4. **Diff by theme and rule text, not by score or rule ID.** Run-to-run, compare which Critical themes are present and which remit clauses are flagged; ignore `R-NN` renumbering and small decimal moves.
 

--- a/docs/understanding-variability.md
+++ b/docs/understanding-variability.md
@@ -9,28 +9,7 @@ Run Praxen twice on the *same* agent, with the *same* Worker Remit and the *same
 
 ## Where the variability comes from
 
-A Praxen analysis has two stages, and only one of them is variable.
-
-```mermaid
-flowchart LR
-  subgraph S1["Stage 1 — LLM (variable)"]
-    direction TB
-    EV["evidence + remit"] --> SY["synthesis:<br/>read · judge · score · write"]
-    SY --> CJ["findings.json"]
-  end
-  subgraph S2["Stage 2 — deterministic (fixed)"]
-    direction TB
-    RN["render.py"] --> HT["analysis.html"]
-    RN --> TX["analysis.txt"]
-  end
-  CJ --> RN
-```
-
-**Stage 1 — synthesis — is done by a large language model** (your coding agent running the `behavior-verifier` skill). Reading the code, deciding what is and isn't a finding, judging severity, and assigning the six RAISE category scores are all *acts of judgement*. The same model given the same evidence will not make every borderline call identically every time — the same way two equally-qualified human reviewers, or the same reviewer on two different days, would write similar-but-not-identical reports. This is inherent to the task, not a defect.
-
-**Stage 2 — rendering — is deterministic.** `render.py` turns the findings JSON into the HTML and TXT views with no model involved; the same JSON always produces byte-identical output. None of the variability lives here. (See [Interpreting Reports](interpreting-reports.md) for the full two-stage picture.)
-
-So the variability you see is entirely the variability of the **synthesis**, captured in `findings.json`.
+A Praxen analysis has two stages, and only one of them varies. **Stage 1 — synthesis** is an LLM job (your coding agent running the skill): reading the code, deciding what is and isn't a finding, judging severity, and assigning the six RAISE category scores are all *acts of judgement*, and the same model won't make every borderline call identically every time — much as two equally-qualified reviewers would write similar-but-not-identical reports. **Stage 2 — rendering (`render.py`)** is deterministic: the same `findings.json` always produces byte-identical HTML/TXT. So all the variability lives in the Stage-1 synthesis, captured in `findings.json`. (See [Interpreting Reports](interpreting-reports.md) for the full two-stage picture and diagram.)
 
 ### Two flavours: variance and drift
 
@@ -58,14 +37,9 @@ The stable signal is the **finding set**; the noisy signal is the **exact number
 
 ## Following up with the LLM
 
-Because the synthesis is an LLM step, you can **interrogate and revise it in conversation** — the report is a starting point, not a verdict. In the same session that produced the analysis (or a new one pointed at the same inputs), you can ask the coding agent to:
+Because synthesis is an LLM step, you can interrogate and revise it in conversation — ask the agent to explain a score, re-examine a finding against its evidence, or re-evaluate a category, and it re-emits the findings JSON. That workflow (and why you revise the manifest/JSON rather than the HTML) is covered in [Challenging and Revising Findings](challenging-findings.md).
 
-- **Explain a call** — *"Why did you score Implement Zero Trust 1 and not 2?"* or *"What evidence backs finding PRAX-…-004?"*
-- **Re-examine a specific finding** — *"Re-check the `/read-only` finding against `commands.py`; is the severity right?"* The agent re-reads the artifact and either confirms or revises.
-- **Challenge a score** — if you believe a control was under- or over-credited, say so with the file/line; the agent can re-evaluate that category and re-emit the findings JSON.
-- **Re-run the whole analysis** — ask for a fresh pass to see whether a borderline result reproduces.
-
-This is the intended workflow for disagreements and close calls. See [Challenging and Revising Findings](challenging-findings.md) for how revisions flow back into the canonical JSON (and why you edit the manifest/JSON and re-render rather than hand-editing the HTML).
+The move specific to *variability*: **re-run the whole analysis** and see whether a borderline result reproduces. If it holds, it's real; if it swings, the target is judgement-sensitive (above) and worth characterising over several runs — see below.
 
 ## When stability matters more than runtime
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -82,7 +82,7 @@ Coverage and confidence increase with each additional input shape — see the [E
 
 ### For highest scan fidelity: run in a fresh context
 
-A scan run in the same session that explored the workspace earlier (while authoring the remit, reading code, or doing any other prep work) will systematically under-read during the Step 4 artifact sweep — the scanner pattern-matches against what it already knows rather than doing a full cold discovery. The `artifact_count` in the report only reflects what was read *during the scan steps*, not what the session already holds in memory. On large codebases this gap is real: in a validation run of the same Hermes Agent workspace, a cold-context scan read 3× as many artifacts and found evidence that shifted four RAISE categories upward by one point each.
+A scan run in the same session that explored the workspace earlier (while authoring the remit, reading code, or doing prep work) will systematically **under-read** during the Step 4 artifact sweep — the scanner pattern-matches against what it already knows rather than doing a full cold discovery. On a large codebase the gap is real: a cold-context scan reads materially more of the workspace, and that extra evidence can move RAISE scores upward — so a warm-context scan tends to *under*-report.
 
 **The recommended approach for a high-confidence scan:** spawn a subagent with no prior context and point it at the workspace. In Claude Code, the Agent tool sends a fresh instance with no conversation history:
 
@@ -211,13 +211,13 @@ The skill couldn't find the path you named. Most common causes:
 
 ### Mid-analysis context auto-compaction (silent quality loss)
 
-Long scans on agents with a lot of evidence can exceed the coding agent's context window. Auto-compaction is *silent* — the run keeps going, but findings gathered early get summarised away before the report is written. Symptoms:
+A long scan can exceed the context window and **auto-compact mid-run** — silently, so the run still finishes but findings gathered early get summarised away before the report is written. Symptoms:
 
 - The interim overview Praxen prints to stdout names findings the final HTML doesn't include.
 - The HTML report looks suspiciously thin compared to the workspace's complexity.
 - The agent suddenly switches to ad-hoc Python to "fix up" the JSON near the end of the run.
 
-What to do is in *Large workspaces and context sizing* above — the short version is: re-run in a larger window with a tighter scope, or recover from the draft manifest. A report produced through a mid-synthesis compaction should be treated as possibly incomplete until you've done one of those.
+→ Prevention and recovery (a larger window, tighter scope, and the draft-manifest safety net) are covered in [Large workspaces and context sizing](#large-workspaces-and-context-sizing) above.
 
 ### Scan stopped emitting output for several minutes (streaming hiccup)
 

--- a/docs/writing-remits.md
+++ b/docs/writing-remits.md
@@ -31,7 +31,7 @@ Hand-authoring is the ideal path — you understand the agent's intended behavio
 
 Ask Claude Code to *"draft a Worker Remit for this agent"* with the description or docs available, and the skill walks the `WORKER_REMIT_template.md` structure to produce a complete first draft. Treat the result as a starting point, not a finished remit: review every section, tighten anything vague (see [the specificity test](#the-specificity-test)), and make sure the **forbidden** actions reflect *your* intent — a drafted remit is only as good as what it had to work from.
 
-Pay particular attention to any clause tagged `[Inferred]` — these are places where the documentation was ambiguous and the skill made its best guess. They are focal review checkpoints, not finished policy.
+The skill authors from the agent's **documentation** — it states what the docs say the agent *should* do and leaves verifying the code to the scan, so the policy body carries no guesses or tags (every clause is a stated obligation). Where the docs don't settle a decision only you can make — authorized scope, thresholds, the counterparty allowlist — the skill collects those in an **"Open Questions for the operator"** section at the end of the file, below the closing footer. **Resolve those before you rely on the remit:** answer each as a real clause or delete it.
 
 ---
 
@@ -127,7 +127,7 @@ See [Challenging and Revising Findings](challenging-findings.md) for guidance on
 - **Listing tools and forgetting boundaries.** "The agent has Email, Slack, and Calendar tools" is a description. *"Email may only be sent to addresses in the authorized counterparty list; Slack messages may only be sent to channels listed in `approved_channels`; Calendar invites may only be issued to known contacts"* is a remit.
 - **Using "should" instead of "must".** Make rules unconditional. *"Should treat unknown senders carefully"* is unverifiable. *"Must escalate unknown senders to the operator before any reply"* is checkable.
 - **Forgetting forbidden domains of work.** Most remits do well at saying what the agent should do, less well at what it must never do. Both are necessary — a wide-open scope produces large compound findings.
-- **Writing restrictions for under-documented capabilities.** If documentation names a feature without scoping it — *"supports SSH tunnel mode"*, *"executes shell commands"* — don't write a MUST NOT clause based on an assumed scope. A prohibition that contradicts the implementation produces a Critical finding that is a remit error, not a code vulnerability. Let the skill tag its inference as `[Inferred]` and resolve the scope at review time.
+- **Writing restrictions for under-documented capabilities.** If documentation names a feature without scoping it — *"supports SSH tunnel mode"*, *"executes shell commands"* — don't write a fabricated MUST NOT based on an assumed scope (a prohibition that contradicts the implementation produces a Critical finding that is a remit error, not a code vulnerability). The skill instead states the *conservative security intent* the feature implies — e.g. *"an SSH tunnel MUST bind loopback and MUST NOT expose a service publicly"* — and lets the scan check it; whether the feature should be authorized *at all* goes in the Open Questions list, not as a guessed clause.
 
 ---
 

--- a/docs/writing-remits.md
+++ b/docs/writing-remits.md
@@ -31,7 +31,7 @@ Hand-authoring is the ideal path — you understand the agent's intended behavio
 
 Ask Claude Code to *"draft a Worker Remit for this agent"* with the description or docs available, and the skill walks the `WORKER_REMIT_template.md` structure to produce a complete first draft. Treat the result as a starting point, not a finished remit: review every section, tighten anything vague (see [the specificity test](#the-specificity-test)), and make sure the **forbidden** actions reflect *your* intent — a drafted remit is only as good as what it had to work from.
 
-Pay particular attention to any clause tagged `[Inferred]` — these are places where the documentation was ambiguous and the skill made its best guess. They are focal review checkpoints, not finished policy. For multi-component deployments, confirm the scope note in the Mission section correctly identifies the primary RAISE subject and that per-component rules use sub-headings within existing sections rather than new top-level sections.
+Pay particular attention to any clause tagged `[Inferred]` — these are places where the documentation was ambiguous and the skill made its best guess. They are focal review checkpoints, not finished policy.
 
 ---
 
@@ -52,6 +52,8 @@ The template is a complete reference, but the load-bearing sections are:
 - **Escalation Rules** — what triggers halt, alert, log-only
 
 If a section doesn't apply to your agent, leave it minimal but explain why — Praxen will note vague or missing rules.
+
+**Multi-component deployments** (e.g. an LLM agent plus an operator or desktop layer) go in **one** combined remit, not several: name the primary RAISE subject in a scope note in the Mission, and give each component its own sub-headings *within* the existing sections rather than adding new top-level sections.
 
 ---
 

--- a/docs/writing-remits.md
+++ b/docs/writing-remits.md
@@ -53,7 +53,7 @@ The template is a complete reference, but the load-bearing sections are:
 
 If a section doesn't apply to your agent, leave it minimal but explain why — Praxen will note vague or missing rules.
 
-**Multi-component deployments** (e.g. an LLM agent plus an operator or desktop layer) go in **one** combined remit, not several: name the primary RAISE subject in a scope note in the Mission, and give each component its own sub-headings *within* the existing sections rather than adding new top-level sections.
+**Multi-component deployments** (e.g., an LLM agent plus an operator or desktop layer) go in **one** combined remit, not several: name the primary RAISE subject in a scope note in the Mission, and give each component its own sub-headings *within* the existing sections rather than adding new top-level sections.
 
 ---
 


### PR DESCRIPTION
## Editorial scrub of `docs/`

A pass for tightness and clarity across the docs folder, from a 4-reviewer scrub that verified every claim against the actual repo. **No content rewritten — duplication is removed or relocated to its owning doc.** Net **−400 words / −51 lines**; the only file with a real sprawl problem (`usage.md`) is the biggest beneficiary.

### `usage.md` — the main target
- **Collapsed the "Mid-analysis context auto-compaction" troubleshooting entry** to its symptom list + a link to *Large workspaces and context sizing*, which already owns the full recovery procedure (the entry even ended by pointing back there). The compaction/draft-manifest story was told ~4×.
- Trimmed the fresh-context section's one-off Hermes benchmark ("3× artifacts, four categories up") and `artifact_count` internals to the actionable point: warm-context scans under-read.

### One-owner cleanups (same set-piece was in 2–3 docs)
- **The "LLM synthesis vs deterministic render" two-stage split** — `interpreting-reports.md` owns it (prose + diagram); `understanding-variability.md` now compresses to ~4 sentences + a cite and jumps straight to its unique content (variance/drift, the ±ranges table, N-run aggregation, the `R-NN`-not-stable tip).
- **"Maturity isn't a school grade / 2.5 is normal"** — `RAISE.md` owns it; `interpreting-reports.md` §11 trimmed to a pointer.
- `understanding-variability.md` "Following up with the LLM" trimmed to a pointer to `challenging-findings.md` + the variability-specific re-run point.

### Polish
- `RAISE.md` — Zero-Trust "counts double" rationale stated 3× (cut from the category blurb, kept in the weights section); dropped the weights **pie chart** (the table has the same data + a "Why" column).
- `owasp.md` — "OWASP, briefly" boilerplate → one sentence; replaced undefined "OpenClaw-style workers" with "autonomous, tool-using agents."
- `installation.md` — cut the Python-3.8 EOL/version-history trivia.
- `interpreting-reports.md` — softened the JSON cross-field-invariant enumeration to a `PRAXEN_SPEC` §6 pointer (it also overstated "equals" vs the code's 0.011 tolerance).
- `writing-remits.md` — moved the dense multi-component clause into the Required-sections structure guidance.

**Left alone** (already tight): `challenging-findings.md`, `index.md`, `quickstart.md`.

Separate from #55 (the OWASP-link add) and touches different line-regions, so the two merge independently in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
