### PR TITLE
ci(branch-drift): assert main is an ancestor of dev (not just version)

### DIFF
--- a/.github/workflows/branch-drift.yml
+++ b/.github/workflows/branch-drift.yml
@@ -1,14 +1,18 @@
 # Copyright 2026 Exabeam, Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Fails if `dev` is on an OLDER release than `main` — i.e. a release (or hotfix)
-# landed on `main` and was never back-merged into `dev`. See CONTRIBUTING.md,
-# "Keeping `dev` in sync with `main`".
+# Fails if `main` is NOT an ancestor of `dev` — i.e. the two branches have
+# diverged in history (a release or hotfix landed on `main` and was never
+# fast-forwarded back into `dev`). See CONTRIBUTING.md, "Keeping `dev` in sync
+# with `main`".
 #
-# This deliberately checks the release VERSION, not a raw `git diff`: `dev` is
-# expected to be *ahead* of `main` between releases (unreleased feature work),
-# and squash-merging means the two branches never share commit SHAs. The only
-# real failure is `dev` sitting on an older version than `main`.
+# This asserts the real invariant — every `main` commit is reachable from
+# `dev` — rather than only comparing release versions. With the merge-commit /
+# fast-forward promotion model (promote `dev -> main` by a merge commit, never
+# squash, then fast-forward `dev` back up to `main`), `main` is always an
+# ancestor of `dev`. The previous version-only check had a blind spot: through
+# the 0.7.5 -> 0.7.7 gap `dev` stayed *ahead* on version the whole time while
+# the histories silently diverged, so it never fired. Ancestry catches that.
 name: Branch drift
 
 on:
@@ -20,25 +24,29 @@ permissions:
   contents: read
 
 jobs:
-  dev-not-behind-main:
+  main-ancestor-of-dev:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: dev must not be on an older release than main
+      - name: main must be an ancestor of dev (no history divergence)
         run: |
           git fetch -q origin main dev
           ver() { git show "origin/$1:.claude-plugin/plugin.json" \
             | sed -nE 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -1; }
           dev_v="$(ver dev)"; main_v="$(ver main)"
           echo "dev=$dev_v  main=$main_v"
-          if [ -z "$dev_v" ] || [ -z "$main_v" ]; then
-            echo "::error::could not read plugin.json version on dev and/or main"; exit 1
+          if git merge-base --is-ancestor origin/main origin/dev; then
+            echo "OK: main is an ancestor of dev — histories are converged."
+            exit 0
           fi
-          newest="$(printf '%s\n%s\n' "$dev_v" "$main_v" | sort -V | tail -1)"
-          if [ "$dev_v" != "$main_v" ] && [ "$newest" = "$main_v" ]; then
-            echo "::error::dev ($dev_v) is behind main ($main_v) — a release landed on main without a back-merge. Open chore/sync-dev-with-main (git merge origin/main into dev, resolve in favour of main). See CONTRIBUTING.md, 'Keeping dev in sync with main'."
-            exit 1
-          fi
-          echo "OK: dev ($dev_v) is not behind main ($main_v)."
+          echo "::error::main is NOT an ancestor of dev — the branches have diverged in history."
+          echo "main ($main_v) carries commit(s) not in dev's history:"
+          git log --oneline origin/dev..origin/main | sed 's/^/  /'
+          echo ""
+          echo "Realign (CONTRIBUTING.md, 'Keeping dev in sync with main'):"
+          echo "  git checkout dev && git merge --ff-only origin/main && git push origin dev"
+          echo "If a fast-forward is refused, main was advanced without going through dev —"
+          echo "promote releases by MERGE COMMIT (never squash) so main stays an ancestor of dev."
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,11 +118,17 @@ reviewed PR):
 
 If the histories have **already** diverged (a squash slipped through, or a commit
 landed on `main` outside this flow), don't squash-paper-over it — reconcile so the
-invariant holds again: rebuild `dev` as `origin/main` plus a cherry-pick of just
-the unreleased commits (`git reset --hard origin/main` then `git cherry-pick
---signoff <new commits>`), confirm the tree is byte-identical to the work you
-meant to keep, and force-push `dev`. This drops redundant already-released commits
-(and is how the 0.7.5→0.7.8 gap was finally closed).
+invariant holds again. Rebuild on a **temporary branch** off `origin/main` — never
+`reset --hard` `dev` in place, or you lose the commit hashes you still need to
+cherry-pick:
+```
+git checkout -b dev-rebuild origin/main
+git cherry-pick --signoff <the unreleased commits>   # the new work only
+git diff origin/dev dev-rebuild                       # MUST be empty (byte-identical)
+git push --force-with-lease origin dev-rebuild:dev
+```
+This drops redundant already-released commits (and is how the 0.7.5→0.7.8 gap was
+finally closed).
 
 A scheduled CI check (`.github/workflows/branch-drift.yml`) asserts `main` is an
 ancestor of `dev` and fails the day the histories diverge — catching a missed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,36 +87,46 @@ When you open a PR, GitHub pre-selects the base branch as the repository default
 
 ### Keeping `dev` in sync with `main`
 
-`main` and `dev` **diverge by construction**: a release is squash-merged from a
-`release/x.y` branch into `main`, which creates a new commit `dev` doesn't share.
-If release-only content — the version bump, the `CHANGELOG` entry, the frozen
-baseline, the spec edits — is authored on the release branch and never returns,
-`dev` silently falls *behind* `main`, and every release widens the gap. (This is
-how `dev` ended up two releases behind through 0.7.7.)
+The invariant: **`main` is always an ancestor of `dev`** — `dev` is `main` plus
+the unreleased work, never a divergent history. Hold that and the two branches
+can never drift.
 
-The standing rule (maintainers — `dev` is unprotected):
+What broke it before: releases were **squash**-merged `dev -> main`. A squash
+discards the shared-parent link, so `main`'s release commit shared no history
+with `dev`; the merge-base froze (at 0.7.5) and every release widened the gap,
+even though the *content* stayed in sync via catch-up PRs. A later `dev -> main`
+then three-wayed from the frozen base and conflicted on everything. The trap was
+invisible to a version check because `dev` stayed *ahead* on version the whole
+time. (This is how `dev` ended up two releases behind through 0.7.7.)
 
-- **Realign `dev` to `main` immediately after every release (and any hotfix).** As
-  soon as the release squash lands on `main` and the `vX.Y.Z` tag is cut, run —
-  **before any new feature work** —
+The model that prevents it (maintainers — `dev` is unprotected, `main` requires a
+reviewed PR):
+
+- **Feature work → `dev`: squash-merge.** Short-lived branches, deleted on merge —
+  squash keeps `dev` tidy and is correct here.
+- **Release `dev → main`: MERGE COMMIT, never squash.** Promote the release PR with
+  a merge commit (`gh pr merge <n> --merge`, *not* `--squash`, *not*
+  `--delete-branch` — `dev` is long-lived). This keeps `dev`'s commits as ancestors
+  of `main`. Author the version bump, `CHANGELOG`, and baseline freeze on `dev`
+  first (so `main` never holds content `dev` lacks), then tag `vX.Y.Z` on `main`.
+- **Immediately after the promotion, fast-forward `dev` up to `main`:**
   ```
-  git fetch origin && git checkout dev && git reset --hard origin/main && git push --force-with-lease origin dev
+  git fetch origin && git checkout dev && git merge --ff-only origin/main && git push origin dev
   ```
-  `dev` restarts cleanly from the released commit, so it can never sit behind
-  `main`. This step has existed since 0.7.2; skipping it after 0.7.5 is how `dev`
-  ended up two releases behind through 0.7.7.
-- **If `dev` has *already* diverged with unreleased work** (so a hard reset would
-  discard it), don't reset — recover with a `chore/sync-dev-with-main` PR instead:
-  `git merge origin/main` into `dev`, resolving squash conflicts in favour of
-  `main` (the content-newer side). This is how the 0.7.7 gap was reconciled.
-- **Optionally, finalize releases *through* `dev`** (author the version bump,
-  `CHANGELOG`, and baseline freeze as PRs into `dev`, or merge the `release/x.y`
-  branch back into `dev`) so `main` never holds content that isn't already on
-  `dev` — which makes the realign a clean no-op.
+  Now `dev == main` and `main` is (trivially) an ancestor of `dev`. The FF is
+  always clean because the merge commit is a descendant of `dev`.
 
-A scheduled CI check (`.github/workflows/branch-drift.yml`) fails if `dev` is ever
-on an older release than `main`, so a skipped realign is caught the next day
-instead of accumulating across releases.
+If the histories have **already** diverged (a squash slipped through, or a commit
+landed on `main` outside this flow), don't squash-paper-over it — reconcile so the
+invariant holds again: rebuild `dev` as `origin/main` plus a cherry-pick of just
+the unreleased commits (`git reset --hard origin/main` then `git cherry-pick
+--signoff <new commits>`), confirm the tree is byte-identical to the work you
+meant to keep, and force-push `dev`. This drops redundant already-released commits
+(and is how the 0.7.5→0.7.8 gap was finally closed).
+
+A scheduled CI check (`.github/workflows/branch-drift.yml`) asserts `main` is an
+ancestor of `dev` and fails the day the histories diverge — catching a missed
+fast-forward (or an accidental squash promotion) before it accumulates.
 
 ## Before you open a PR
 


### PR DESCRIPTION
Follow-up to the 0.7.8 release — locks in the structural fix for the `dev`/`main` divergence that blocked the release.

## What changed
- **`branch-drift.yml`** now asserts the real invariant — `git merge-base --is-ancestor origin/main origin/dev` — instead of comparing release versions. The version-only check had a blind spot: through the **0.7.5 → 0.7.7** history gap, `dev` stayed *ahead* on version the whole time, so it never fired while the histories silently diverged. On failure it now prints the offending `main`-only commits and the fast-forward realign command.
- **`CONTRIBUTING.md` "Keeping `dev` in sync with `main`"** rewritten for the promotion model adopted in 0.7.8: squash feature→`dev`, but promote `dev`→`main` by **merge commit** (never squash) then **fast-forward `dev` up to `main`** — so `main` is an ancestor of `dev` by construction and the drift can't recur.

## Verified
- YAML parses; the ancestry assertion passes against the current converged branches (`dev` == `main` == `028568f`).

> The repo merge setting was already switched to allow merge commits (kept squash for feature→dev) as part of the 0.7.8 promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)