### PR TITLE
fix(coverage): version-aware baseline sort + clamp histogram bucket

### DIFF
--- a/tests/baselines/owasp_coverage.py
+++ b/tests/baselines/owasp_coverage.py
@@ -25,6 +25,15 @@ from pathlib import Path
 
 THIS_DIR = Path(__file__).resolve().parent
 
+def _baseline_sort_key(p: Path):
+    """Version-aware sort key for `v*` baseline dirs: compares the numeric
+    version components, so v0.7.10 sorts above v0.7.9 (plain name sorting puts
+    it below). Non-numeric parts and unparseable names fall back to 0."""
+    version = p.name[1:].split("-", 1)[0]  # "0.7.10" from "v0.7.10-claude48"
+    nums = [int(part) if part.isdigit() else 0 for part in version.split(".")]
+    return (nums, p.name)
+
+
 def _default_baseline() -> Path:
     """Return the canonical baseline named in CURRENT, falling back to the newest v* dir."""
     current_file = THIS_DIR / "CURRENT"
@@ -34,7 +43,7 @@ def _default_baseline() -> Path:
         if candidate.is_dir():
             return candidate
     candidates = sorted([p for p in THIS_DIR.glob("v*") if p.is_dir()],
-                        key=lambda p: p.name, reverse=True)
+                        key=_baseline_sort_key, reverse=True)
     return candidates[0] if candidates else THIS_DIR / "v0.7.7-claude48"
 
 DEFAULT_BASELINE = _default_baseline()

--- a/tests/baselines/raise_coverage.py
+++ b/tests/baselines/raise_coverage.py
@@ -28,6 +28,15 @@ from statistics import mean, stdev
 
 THIS_DIR = Path(__file__).resolve().parent
 
+def _baseline_sort_key(p: Path):
+    """Version-aware sort key for `v*` baseline dirs: compares the numeric
+    version components, so v0.7.10 sorts above v0.7.9 (plain name sorting puts
+    it below). Non-numeric parts and unparseable names fall back to 0."""
+    version = p.name[1:].split("-", 1)[0]  # "0.7.10" from "v0.7.10-claude48"
+    nums = [int(part) if part.isdigit() else 0 for part in version.split(".")]
+    return (nums, p.name)
+
+
 def _default_baseline() -> Path:
     """Return the canonical baseline named in CURRENT, falling back to the newest v* dir."""
     current_file = THIS_DIR / "CURRENT"
@@ -37,7 +46,7 @@ def _default_baseline() -> Path:
         if candidate.is_dir():
             return candidate
     candidates = sorted([p for p in THIS_DIR.glob("v*") if p.is_dir()],
-                        key=lambda p: p.name, reverse=True)
+                        key=_baseline_sort_key, reverse=True)
     return candidates[0] if candidates else THIS_DIR / "v0.7.7-claude48"
 
 DEFAULT_BASELINE = _default_baseline()
@@ -296,7 +305,7 @@ def overall_histogram(all_weighted):
     # Buckets: 0–<1, 1–<2, 2–<3, 3–<4, 4–<5, 5
     buckets = [[] for _ in range(6)]
     for w in all_weighted:
-        buckets[min(5, int(w))].append(w)
+        buckets[max(0, min(5, int(w)))].append(w)
 
     n = len(all_weighted)
     pop_avg = mean(all_weighted)


### PR DESCRIPTION
Addresses the three Gemini review comments on the #63 coverage scripts (re-surfaced on the dev→main promotion #67). All on already-merged code; both fixes are small and behavior-preserving for current data.

- **Version-aware baseline sort** (`owasp_coverage.py`, `raise_coverage.py`) — `_default_baseline()`'s fallback sorted `v*` dirs alphabetically, so `v0.7.10` would sort *below* `v0.7.9`. Replaced with a numeric version-component key. It's a fallback only (`CURRENT` pins the canonical dir), but it's a real latent ordering bug. Verified: `v0.7.10` now sorts above `v0.7.9`.
- **Clamp histogram bucket** (`raise_coverage.py`) — `min(5, int(w))` → `max(0, min(5, int(w)))` so a negative weighted score can't index from the list end. Defensive; valid scores are 0–5.

**No report regen:** rendering with these changes is byte-identical except the volatile "Generated … UTC" line; `CURRENT` still selects `v0.7.7-claude48`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)