### PR TITLE
Promote dev → main: gate manifest test + tighten determinism/read-only claims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Render pipeline tests (schema + render + golden files)
         run: python3 tests/render/test_render.py
+      - name: Manifest→findings converter tests (Step 9.9 → Step 10)
+        run: python3 tests/render/test_manifest_to_findings.py
       - name: Package the distributable (sanity)
         run: bash build.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,9 @@ jobs:
             exit 1
           fi
       - name: Run the test suite
-        run: python3 tests/render/test_render.py
+        run: |
+          python3 tests/render/test_render.py
+          python3 tests/render/test_manifest_to_findings.py
       - name: Install build-only docs dependency
         # Lets build.sh rebuild guide/ and enforce the docs freshness backstop.
         # Build-only; never shipped in the plugin (which stays stdlib-only).

--- a/PRAXEN_SPEC.md
+++ b/PRAXEN_SPEC.md
@@ -59,7 +59,7 @@ Reports must never contain the literal value of a secret, credential, token, pas
 
 ### 2.4 Least privilege
 
-Praxen operates read-only on the agent's workspace. It does not take action on behalf of the agent. It does not modify the agent's code, skill files, configuration, or dependencies. It writes output only to its own `./reports/` directory in the current working directory.
+Praxen is designed to operate read-only on the agent's workspace: the skill reads the agent's artifacts and writes output only to its own `./reports/` directory in the current working directory. It does not take action on behalf of the agent, and does not modify the agent's code, skill files, configuration, or dependencies. This is a behavioral contract of the skill's instructions, not a technical sandbox — Praxen runs with the coding agent's ordinary tool access (including Bash and Write), so the read-only posture is enforced by convention rather than by an isolation boundary. (This is the same declared-versus-enforced distinction Praxen itself flags when it scans other agents.)
 
 ### 2.5 Separation
 
@@ -492,7 +492,7 @@ The Praxen operationalizes the **RAISE Security Review Skill** — a structured 
 The key design decisions in Praxen's synthesis:
 - A single Worker Remit serves as the policy baseline — Praxen's primary signal is divergence between declared policy and observed implementation.
 - A unified canonical findings JSON with dual RAISE + OWASP classification is the complete record; it carries every prose field the report shows, so JSON-only consumers see the same content as humans.
-- A canonical HTML template *plus* two deterministic Python scripts in sequence (`manifest_to_findings.py` translates the Step 9.9 draft manifest into the canonical findings JSON; `render.py` substitutes the JSON into the template): the LLM does judgment, code does the mechanical substitution — so every report looks identical, byte-for-byte, regardless of which model produced the findings, and a malformed analysis fails loudly at the schema validator rather than producing a broken report.
+- A canonical HTML template *plus* two deterministic Python scripts in sequence (`manifest_to_findings.py` translates the Step 9.9 draft manifest into the canonical findings JSON; `render.py` substitutes the JSON into the template): the LLM does judgment, code does the mechanical substitution — so the report's structure and styling are identical regardless of which model produced the findings (the renderer is deterministic: a given findings JSON always yields byte-identical HTML and TXT), and a malformed analysis fails loudly at the schema validator rather than producing a broken report. The findings themselves are LLM judgment and vary run to run; it is the rendering, not the analysis, that is byte-deterministic.
 - The package is self-contained: drop the directory, run the skill, read the report. No installer, no config file, no persistent state. (Python 3 is the one runtime besides Claude Code — stdlib only.)
 
 ---

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,7 +7,7 @@
 
 Running a Praxen analysis takes two inputs: a **Worker Remit** (the agent's declared policy) and **evidence** (whatever the agent's code, deployment state, behavioral records, or development/governance docs can provide). Praxen produces three output files in `./reports/`.
 
-**Praxen is a read-only external observer.** It reads the artifacts you point it at and writes a local report; it does not modify the agent, sit in its control path, or call any service Praxen itself controls. That makes it suitable as an independent verifier — not self-attestation by the agent under analysis.
+**Praxen is designed as a read-only external observer.** It reads the artifacts you point it at and writes a local report; it does not modify the agent, sit in its control path, or call any service Praxen itself controls. This read-only posture is a discipline of the skill's instructions rather than a technical sandbox — the analysis runs with the coding agent's ordinary Bash/Write access — but it keeps Praxen suitable as an independent verifier, not self-attestation by the agent under analysis.
 
 This page covers the end-to-end run. For installing Praxen, see [Installation](installation.md). For authoring the Worker Remit, see [Writing Worker Remits](writing-remits.md).
 

--- a/guide/usage.html
+++ b/guide/usage.html
@@ -236,7 +236,7 @@ img { max-width: 100%; display: block; }
   <main class="docs-main">
     <article class="prose"><h1 id="usage">Usage</h1>
 <p>Running a Praxen analysis takes two inputs: a <strong>Worker Remit</strong> (the agent's declared policy) and <strong>evidence</strong> (whatever the agent's code, deployment state, behavioral records, or development/governance docs can provide). Praxen produces three output files in <code>./reports/</code>.</p>
-<p><strong>Praxen is a read-only external observer.</strong> It reads the artifacts you point it at and writes a local report; it does not modify the agent, sit in its control path, or call any service Praxen itself controls. That makes it suitable as an independent verifier — not self-attestation by the agent under analysis.</p>
+<p><strong>Praxen is designed as a read-only external observer.</strong> It reads the artifacts you point it at and writes a local report; it does not modify the agent, sit in its control path, or call any service Praxen itself controls. This read-only posture is a discipline of the skill's instructions rather than a technical sandbox — the analysis runs with the coding agent's ordinary Bash/Write access — but it keeps Praxen suitable as an independent verifier, not self-attestation by the agent under analysis.</p>
 <p>This page covers the end-to-end run. For installing Praxen, see <a href="installation.html">Installation</a>. For authoring the Worker Remit, see <a href="writing-remits.html">Writing Worker Remits</a>.</p>
 <hr>
 <h2 id="the-two-inputs">The two inputs</h2>

--- a/tests/fixtures/helperbot.from_manifest.json
+++ b/tests/fixtures/helperbot.from_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "2.0",
-  "praxen_version": "0.7.5",
+  "praxen_version": "0.7.8",
   "scan": {
     "agent": "HelperBot",
     "agent_slug": "helperbot",

--- a/tests/render/test_manifest_to_findings.py
+++ b/tests/render/test_manifest_to_findings.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -34,6 +35,7 @@ TEMPLATE = os.path.join(SKILL_DIR, "report_template.html")
 FIXTURE_DIR = os.path.join(REPO_ROOT, "tests", "fixtures")
 MANIFEST = os.path.join(FIXTURE_DIR, "helperbot.manifest.md")
 GOLDEN_JSON = os.path.join(FIXTURE_DIR, "helperbot.from_manifest.json")
+PLUGIN_JSON = os.path.join(REPO_ROOT, ".claude-plugin", "plugin.json")
 
 sys.path.insert(0, SKILL_DIR)
 import schema  # noqa: E402
@@ -67,6 +69,28 @@ def read_bytes(path):
     return Path(path).read_bytes()
 
 
+def live_plugin_version():
+    """The canonical Praxen version the converter stamps into every output —
+    read from .claude-plugin/plugin.json, the same single source of truth the
+    converter's _load_praxen_version() uses."""
+    return json.loads(read_text(PLUGIN_JSON))["version"]
+
+
+_VERSION_RE = re.compile(rb'("praxen_version":\s*")[^"]*(")')
+
+
+def mask_version(data: bytes) -> bytes:
+    """Blank out the praxen_version value for the golden byte-comparison.
+
+    praxen_version is injected from .claude-plugin/plugin.json — it is NOT
+    derived from the manifest — so it tracks the live release and would make the
+    golden go stale on every version bump (which is exactly how this test came to
+    fail silently between 0.7.5 and 0.7.8). The converter's *stamping behavior*
+    is asserted separately below; here we hold it constant so the round-trip
+    checks everything the manifest actually drives."""
+    return _VERSION_RE.sub(rb"\1\2", data)
+
+
 def assert_parse_error(label, manifest_text, expected_substring):
     """Run the parser on `manifest_text`; check that it raises ManifestError
     whose message contains `expected_substring`."""
@@ -90,8 +114,18 @@ with tempfile.TemporaryDirectory() as td:
     check("converter exits 0", res.returncode == 0, res.stderr or res.stdout)
     actual_bytes = read_bytes(out)
     golden_bytes = read_bytes(GOLDEN_JSON)
-    check("output bytes match golden", actual_bytes == golden_bytes,
-          f"actual_len={len(actual_bytes)} golden_len={len(golden_bytes)}")
+    # Compare with praxen_version masked — it's stamped from plugin.json, not the
+    # manifest, so it must not couple the golden to the live release version.
+    masked_actual = mask_version(actual_bytes)
+    masked_golden = mask_version(golden_bytes)
+    check("output bytes match golden (version-masked)", masked_actual == masked_golden,
+          f"actual_len={len(masked_actual)} golden_len={len(masked_golden)}")
+    # …and assert the stamping behavior directly: the converter must write the
+    # current plugin.json version, regardless of what the golden was captured at.
+    stamped = json.loads(actual_bytes).get("praxen_version")
+    live = live_plugin_version()
+    check("converter stamps current plugin.json version", stamped == live,
+          f"stamped={stamped!r} plugin.json={live!r}")
 
 # ── 2. Determinism: rerun produces identical output ─────────────────────────
 print("\n2. Determinism")


### PR DESCRIPTION
Promotes the single commit on `dev` (PR #76) to `main`.

- Gate `tests/render/test_manifest_to_findings.py` in CI (`ci.yml` + `release.yml`); decouple the golden fixture from the live `praxen_version` so it can't silently go stale on a version bump.
- Tighten two overstated claims in `PRAXEN_SPEC.md` / `docs/usage.md`: render-determinism is not whole-report identity, and §2.4 read-only is a behavioral contract of the skill, not a sandbox.

Reported & reviewed by @emmanuelgjr. Already squash-merged to `dev` (CI green). Promotion is a merge commit; `dev` is fast-forwarded up to `main` afterward to preserve the main-is-ancestor-of-dev invariant.