### PR TITLE
test(manifest): harden version-mask regex against colon spacing (#78 follow-up)

### DIFF
--- a/tests/render/test_manifest_to_findings.py
+++ b/tests/render/test_manifest_to_findings.py
@@ -76,7 +76,7 @@ def live_plugin_version():
     return json.loads(read_text(PLUGIN_JSON))["version"]
 
 
-_VERSION_RE = re.compile(rb'("praxen_version":\s*")[^"]*(")')
+_VERSION_RE = re.compile(rb'("praxen_version"\s*:\s*")[^"]*(")')
 
 
 def mask_version(data: bytes) -> bytes:


### PR DESCRIPTION
Addresses @gemini-code-assist's late review comment on #78.

The `praxen_version` mask regex anchored on `"praxen_version":` with no optional whitespace before the colon. The converter emits exactly that today, so the test passes — but this regex is the linchpin of the golden staleness fix from #76. If the serializer's colon spacing ever changed (minification, a reformat), `mask_version()` would silently no-op and the round-trip would fail on the *next* version bump — reintroducing the exact confusing failure #76 fixed.

Broadened to `"praxen_version"\s*:\s*"`, which matches spaced, unspaced, and minified output. Defensive only — no behavior change against current converter output.

- `test_manifest_to_findings.py`: 29 passed, 0 failed.

No rush to promote on its own — this can ride to `main` alongside the next promotion (e.g. the Salesforce example) to avoid a solo cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)