### PR TITLE
fix(site): reduce anchor-jump gap under the sticky nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     /* Tokens, base elements, .grad, .eyebrow, buttons and badges live in
        assets/praxen-theme.css (the shared design system). Only landing-specific
        layout remains below. */
-    html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; scroll-padding-top: 72px; }
+    html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; scroll-padding-top: 24px; }
 
     /* ---------- Nav ---------- */
     header.nav {


### PR DESCRIPTION
**Reported:** clicking a top-nav link (e.g. "What it catches" → `#verify`) leaves a big blank gap before the content.

**Cause:** the anchor is on the right element (the `section-pad` section), but `scroll-padding-top: 72px` stacked on top of each section's own **76px** top padding → jumped content landed ~148px down, ~82px of dead space below the 66px sticky nav.

**Fix:** lower `scroll-padding-top` to 24px. The section's own 76px top padding provides the nav clearance, so content now lands ~34px below the nav. All content anchors are `section-pad` sections; `#top` is `<main>` (clamps to page top), so unaffected. One-line change.

Note: headless `--screenshot` can't capture a smooth-scroll fragment jump, so this is verified by the CSS math (24 + 76 − 66 = 34px gap) — worth a real-browser click to confirm the feel.