### PR TITLE
Pages: reduce nav anchor-jump gap (#86)

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     /* Tokens, base elements, .grad, .eyebrow, buttons and badges live in
        assets/praxen-theme.css (the shared design system). Only landing-specific
        layout remains below. */
-    html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; scroll-padding-top: 72px; }
+    html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; scroll-padding-top: 24px; }
 
     /* ---------- Nav ---------- */
     header.nav {


### PR DESCRIPTION
Promote the one-line nav anchor-offset fix (#86) to main so it's live on Pages. index.html only — the 0.8.0 distro/zip is unaffected, so no new release tag. Merge commit; dev fast-forwarded up after.