### PR TITLE
fix(install): one paste-safe install command on the landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ That's where the risk actually lives: most agentic security and safety failures 
 ---
 
 **📦 Install** — Praxen runs on **Claude Code** and **OpenAI Codex** (same skill, platform-specific packaging):
-- **Claude Code:** `/plugin marketplace add open-agent-ai-security/praxen` then `/plugin install praxen@open-agent-ai-security`
+- **Claude Code:** one command — `claude plugin marketplace add open-agent-ai-security/praxen && claude plugin install praxen@open-agent-ai-security`
 - **OpenAI Codex:** link `skills/behavior-verifier` into `.agents/skills/` and invoke `$praxen:behavior-verifier`
 
 Full guide (including the unzipped-release path, which works for either): [docs/installation.md](docs/installation.md).

--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
     .terminal .bar i:nth-child(1){ background:#ff5f57; } .terminal .bar i:nth-child(2){ background:#febc2e; } .terminal .bar i:nth-child(3){ background:#28c840; }
     .terminal .bar span { margin-left: 8px; font-size: 12.5px; color: var(--muted-2); }
     .terminal pre { margin: 0; padding: 20px 18px; font-family: "SF Mono", ui-monospace, Menlo, Consolas, monospace;
-      font-size: 13.5px; line-height: 1.9; color: #cfe0f2; overflow-x: auto; }
+      font-size: 12px; line-height: 1.95; color: #cfe0f2; overflow-x: auto; }
     .terminal .cmt { color: var(--muted-2); }
     .terminal .pmt { color: var(--orange); user-select: none; }
     .copy-row { display: flex; align-items: center; gap: 12px; margin-top: 18px; }
@@ -445,7 +445,7 @@
           <div>
             <p class="eyebrow">Get started in minutes</p>
             <h2>Install the plugin</h2>
-            <p>Praxen runs as a plugin in your coding agent (such as Claude Code). No <code>pip install</code> needed. Add the marketplace, install, and point it at an agent to evaluate.</p>
+            <p>Praxen runs as a plugin in your coding agent (such as Claude Code). No <code>pip install</code> needed. One command adds the marketplace and installs it — then point Praxen at an agent to evaluate.</p>
             <div class="copy-row">
               <button class="btn btn-primary copy-btn" id="copyBtn" type="button">
                 <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
@@ -460,14 +460,13 @@
             </p>
           </div>
           <div class="terminal">
-            <div class="bar"><i></i><i></i><i></i><span>Claude Code</span></div>
-<pre id="cmd"><span class="cmt"># 1 · add the Praxen marketplace</span>
-<span class="pmt">&gt;</span> /plugin marketplace add open-agent-ai-security/praxen
+            <div class="bar"><i></i><i></i><i></i><span>Terminal</span></div>
+<pre id="cmd"><span class="cmt"># install Praxen in your terminal</span>
+<span class="pmt">$</span> claude plugin marketplace add open-agent-ai-security/praxen
+<span class="pmt">$</span> claude plugin install praxen@open-agent-ai-security
+<span class="pmt">$</span> claude plugin list
 
-<span class="cmt"># 2 · install the plugin</span>
-<span class="pmt">&gt;</span> /plugin install praxen@open-agent-ai-security
-
-<span class="cmt"># 3 · run an analysis</span>
+<span class="cmt"># then, in Claude Code, point it at an agent</span>
 <span class="pmt">&gt;</span> Run a Praxen behavior analysis on ./my-agent</pre>
           </div>
         </div>
@@ -542,10 +541,14 @@
     (function () {
       var btn = document.getElementById('copyBtn');
       var ok = document.getElementById('copyOk');
-      var cmds = [
-        '/plugin marketplace add open-agent-ai-security/praxen',
-        '/plugin install praxen@open-agent-ai-security'
-      ].join('\n');
+      // One flat shell command: add the marketplace, install, then confirm.
+      // The `&&` chain runs in a terminal as a single paste — no in-session
+      // slash-command splitting, so it can't fuse-fail the way two `/plugin`
+      // lines did. Kept on one line (no backslash continuations) so the copied
+      // text pastes and runs verbatim.
+      var cmds = 'claude plugin marketplace add open-agent-ai-security/praxen'
+               + ' && claude plugin install praxen@open-agent-ai-security'
+               + ' && claude plugin list';
       if (!btn) return;
 
       function flash(msg, ms) {


### PR DESCRIPTION
## The bug
The install card's single **Copy install command** button copied two **in-session slash commands** joined by a newline:

```
/plugin marketplace add open-agent-ai-security/praxen
/plugin install praxen@open-agent-ai-security
```

Claude Code submits one slash-command per message, so pasting both fuses them — the first `/plugin` swallows the second line as its arguments, producing a bogus marketplace spec (observed: a clone of `…/marketplaces/open-agent-ai-security-praxen--plugin-install-praxen`, which then errored on SSH host-key verification — a downstream symptom, not the root cause). There is no way to make two slash commands paste-safe in a single submission.

## The fix
Switch the landing page to the **terminal CLI form** the docs already recommend (`docs/installation.md` leads with `claude plugin …` and explicitly warns that in-session slash commands "occasionally fall through"):

- **The button copies one flat shell command:**
  ```
  claude plugin marketplace add open-agent-ai-security/praxen && claude plugin install praxen@open-agent-ai-security && claude plugin list
  ```
  An `&&` chain runs as a single terminal paste — nothing to fuse. The trailing `claude plugin list` confirms the install (read-only; `&&` short-circuits, so it only runs if install succeeded). Even a hand-copier is safe now, since newline-separated `claude plugin …` lines execute fine in a shell.
- **The terminal mock shows three clean, separate `$` command lines** — decoupled from the copied compound command — with step 3 left as the in-session `> Run a Praxen behavior analysis…` prompt. Terminal font dropped to 12px so the longest line fits the narrow column without clipping.

## Consistency
Moved `README.md`'s Claude Code install snippet off the same fragile `/plugin` slash form onto the matching `claude plugin … && …` one-liner — so the landing page, README, and `docs/installation.md` all agree.

## Verification
Pasting the copied command in a terminal ran `add → install → list` in order and reported the plugin enabled. (Tested live.)

> **Live-site note:** GitHub Pages serves from `main`, so this reaches the live landing page only after a `dev → main` promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)