### PR TITLE
fix(readme): static release pill + version-guard (no GitHub-API dependency)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,10 +145,13 @@ a tag.
 
 **Cutting a release**
 
-1. Land all changes on `dev`; bump the version everywhere the 4-way guard checks
-   (`PRAXEN_SPEC.md` + the three plugin manifests) plus `README.md` and
-   `CHANGELOG.md`; run `./build.sh` locally to confirm the version guard and the
-   `guide/` docs-freshness check pass.
+1. Land all changes on `dev`; bump the version everywhere the version guards
+   check — `PRAXEN_SPEC.md` + the three plugin manifests (`build.sh`'s 4-way
+   guard) **and** the static `release-v<version>` badge in `README.md`
+   (the 6-way unit guard in `tests/render/test_plugin_manifests.py`; remember
+   to escape the SemVer `-` as `--`, e.g. `release-v1.0.0--rc.1-blue`) — plus
+   `CHANGELOG.md`; run `./build.sh` and `python3 tests/render/test_plugin_manifests.py`
+   locally to confirm the version guards and the `guide/` docs-freshness check pass.
 2. Promote `dev → main` (merge commit, never squash), then fast-forward `dev`
    back up so `main` stays an ancestor of `dev`.
 3. Push the matching `v<version>` tag to fire `release.yml`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 **agent behavior verifier**
 
 [![CI](https://github.com/open-agent-ai-security/praxen/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agent-ai-security/praxen/actions/workflows/ci.yml)
-[![Latest release](https://img.shields.io/github/v/release/open-agent-ai-security/praxen?sort=semver)](https://github.com/open-agent-ai-security/praxen/releases)
+[![Latest release](https://img.shields.io/badge/release-v1.0.0--rc.1-blue)](https://github.com/open-agent-ai-security/praxen/releases)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://www.python.org/downloads/)
 

--- a/tests/render/test_plugin_manifests.py
+++ b/tests/render/test_plugin_manifests.py
@@ -105,14 +105,25 @@ def main():
     m = re.search(r"\*\*Version:\*\*\s*([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)",
                   SPEC.read_text(encoding="utf-8"))
     spec_ver = m.group(1) if m else None
+
+    # README release pill is a STATIC shields badge (no GitHub-API dependency, so
+    # it can't error or lag) — but a static badge can drift, so the version it
+    # displays must agree with the manifests too. shields escapes a literal '-'
+    # in the badge message as '--', e.g. release-v1.0.0--rc.1-blue → 1.0.0-rc.1.
+    README = REPO_ROOT / "README.md"
+    rb = re.search(r"img\.shields\.io/badge/release-v(.+?)-(?:blue|orange|green|brightgreen|lightgrey|informational)\b",
+                   README.read_text(encoding="utf-8"))
+    readme_ver = rb.group(1).replace("--", "-") if rb else None
+
     versions = {
         "claude plugin.json": cp.get("version"),
         "codex plugin.json": xp.get("version"),
         "marketplace plugins[0]": entry.get("version"),
         "marketplace metadata": (mp.get("metadata") or {}).get("version"),
         "PRAXEN_SPEC.md": spec_ver,
+        "README release badge": readme_ver,
     }
-    check("all manifest versions + PRAXEN_SPEC.md agree",
+    check("all manifest versions + PRAXEN_SPEC.md + README badge agree",
           None not in versions.values() and len(set(versions.values())) == 1,
           f"versions={versions}")
     check("version is semver (MAJOR.MINOR.PATCH)",

--- a/tests/render/test_plugin_manifests.py
+++ b/tests/render/test_plugin_manifests.py
@@ -110,8 +110,11 @@ def main():
     # it can't error or lag) — but a static badge can drift, so the version it
     # displays must agree with the manifests too. shields escapes a literal '-'
     # in the badge message as '--', e.g. release-v1.0.0--rc.1-blue → 1.0.0-rc.1.
+    # Match badge/release-v<message>-<color>) : non-greedy message up to the
+    # color segment, any alnum color (named or hex), anchored on the markdown
+    # ')' so a greedy capture can't bleed into the link URL's own hyphens.
     README = REPO_ROOT / "README.md"
-    rb = re.search(r"img\.shields\.io/badge/release-v(.+?)-(?:blue|orange|green|brightgreen|lightgrey|informational)\b",
+    rb = re.search(r"img\.shields\.io/badge/release-v(.+?)-[A-Za-z0-9]+\)",
                    README.read_text(encoding="utf-8"))
     readme_ver = rb.group(1).replace("--", "-") if rb else None
 


### PR DESCRIPTION
The README release pill was wired to shields.io's dynamic `github/v/release` endpoint, which calls the GitHub API via shields' shared token pool. Two failure modes resulted: it lagged the real version (the `sort=semver` default skips pre-release-suffixed tags, so it showed `v0.8.1` instead of `v1.0.0-rc.1`), and on a cache-miss while that token pool is degraded it rendered **"Unable to select next GitHub token from pool"** right on the README. Putting the storefront pill on that external API path was the fragile call — this removes the dependency.

### Changes
- **README** → static shields badge `release-v1.0.0--rc.1-blue`. No API call, so it can't error or lag; it shows exactly the released version. (Verified: renders `release: v1.0.0-rc.1`.)
- **Drift guard** — a static badge can go stale, so `test_plugin_manifests.py` now checks the README badge version agrees with the manifests + `PRAXEN_SPEC.md` (**5-way → 6-way**). Proven to FAIL on a deliberately-mismatched badge and pass when consistent.
- **CONTRIBUTING** release runbook — spell out bumping the README badge (and escaping the SemVer `-` as `--`) in the version-bump step.

### Tests
`test_plugin_manifests.py` 17/0 (6-way agreement at `1.0.0-rc.1`), `test_render.py` 332/0.

Supersedes #110 (the dynamic `include_prereleases` fix), now moot. Renders live once promoted to `main`; the GA flip will bump this badge alongside the manifests (and the guard enforces it).