### PR TITLE
docs(install): expand the Updating section (manual + auto-update)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -78,16 +78,48 @@ For the first **end-to-end run** on either platform — Worker Remit + agent sou
 
 ## Updating
 
-**Claude Code (plugin marketplace):**
+Every Praxen release bumps the version string, so a new version is always picked up once you refresh — the only question is whether you refresh by hand or let Claude Code do it for you. Check what you currently have with:
 
 ```bash
-claude plugin marketplace update open-agent-ai-security
-claude plugin update praxen@open-agent-ai-security
+claude plugin list      # shows praxen@open-agent-ai-security and its installed version
 ```
 
-Restart Claude Code to apply. (In-session equivalents are the same commands as `/plugin …`.)
+### Claude Code — manual update
 
-**OpenAI Codex / unzipped release:** pull the latest checkout or download the new release zip and replace it — a symlinked skill folder picks up the new version automatically. There is no migration step; Praxen is stateless across analyses.
+Two steps (the catalog refresh and the install are independent), then restart:
+
+```bash
+claude plugin marketplace update open-agent-ai-security   # refresh the catalog from the repo
+claude plugin update praxen@open-agent-ai-security         # install the latest version
+```
+
+Restart Claude Code (or run `/reload-plugins`) to apply. **Don't skip the first command** — on its own, `plugin update` only moves you to the newest version in your *local* catalog cache, which may be stale. The in-session `/plugin marketplace update …` and `/plugin update …` do exactly the same thing.
+
+### Claude Code — auto-update (opt-in)
+
+Auto-update is a **per-marketplace** setting, and for third-party marketplaces like Praxen's it is **off by default** — so out of the box you're on manual updates, and **Claude Code does not notify you** when a newer version exists. To turn it on:
+
+- **Interactively:** `/plugin` → **Marketplaces** tab → select `open-agent-ai-security` → **enable auto-update**. Claude Code then checks for a newer version **at startup** (not on a schedule) and updates automatically.
+- **Fleet-wide (admins)** — in managed `settings.json`:
+
+  ```json
+  {
+    "extraKnownMarketplaces": {
+      "open-agent-ai-security": {
+        "source": { "source": "github", "repo": "open-agent-ai-security/praxen" },
+        "autoUpdate": true
+      }
+    }
+  }
+  ```
+
+- **Global override (env vars):** `DISABLE_AUTOUPDATER=1` turns off *all* auto-updates; add `FORCE_AUTOUPDATE_PLUGINS=1` alongside it to keep plugin auto-updates while disabling Claude Code's own self-update.
+
+> Because Praxen is a security tool, staying current matters — enabling auto-update (or updating on a regular cadence) is recommended.
+
+### OpenAI Codex / unzipped release
+
+There's no marketplace, so updating is manual: `git pull` the checkout (a symlinked skill folder picks up the new version automatically), or download the new release zip and replace it. There's no migration step; Praxen is stateless across analyses.
 
 ## Uninstalling
 

--- a/guide/installation.html
+++ b/guide/installation.html
@@ -284,12 +284,38 @@ cd praxen-VERSION
 <p><strong>Codex:</strong> confirm the skill appears to the model as <code>praxen:behavior-verifier</code> in Codex's skill list. That's the parity check — it confirms discovery, the same way <code>claude plugin list</code> does for Claude Code.</p>
 <p>For the first <strong>end-to-end run</strong> on either platform — Worker Remit + agent source → HTML / JSON / TXT report — see <a href="quickstart.html">Quickstart</a>. It walks through scanning the FinBot agent (source cloned from upstream) against the bundled remit in about five minutes, with the exact Claude Code and Codex commands.</p>
 <h2 id="updating">Updating</h2>
-<p><strong>Claude Code (plugin marketplace):</strong></p>
-<pre><code class="language-bash">claude plugin marketplace update open-agent-ai-security
-claude plugin update praxen@open-agent-ai-security
+<p>Every Praxen release bumps the version string, so a new version is always picked up once you refresh — the only question is whether you refresh by hand or let Claude Code do it for you. Check what you currently have with:</p>
+<pre><code class="language-bash">claude plugin list      # shows praxen@open-agent-ai-security and its installed version
 </code></pre>
-<p>Restart Claude Code to apply. (In-session equivalents are the same commands as <code>/plugin …</code>.)</p>
-<p><strong>OpenAI Codex / unzipped release:</strong> pull the latest checkout or download the new release zip and replace it — a symlinked skill folder picks up the new version automatically. There is no migration step; Praxen is stateless across analyses.</p>
+<h3 id="claude-code-manual-update">Claude Code — manual update</h3>
+<p>Two steps (the catalog refresh and the install are independent), then restart:</p>
+<pre><code class="language-bash">claude plugin marketplace update open-agent-ai-security   # refresh the catalog from the repo
+claude plugin update praxen@open-agent-ai-security         # install the latest version
+</code></pre>
+<p>Restart Claude Code (or run <code>/reload-plugins</code>) to apply. <strong>Don't skip the first command</strong> — on its own, <code>plugin update</code> only moves you to the newest version in your <em>local</em> catalog cache, which may be stale. The in-session <code>/plugin marketplace update …</code> and <code>/plugin update …</code> do exactly the same thing.</p>
+<h3 id="claude-code-auto-update-opt-in">Claude Code — auto-update (opt-in)</h3>
+<p>Auto-update is a <strong>per-marketplace</strong> setting, and for third-party marketplaces like Praxen's it is <strong>off by default</strong> — so out of the box you're on manual updates, and <strong>Claude Code does not notify you</strong> when a newer version exists. To turn it on:</p>
+<ul>
+<li><strong>Interactively:</strong> <code>/plugin</code> → <strong>Marketplaces</strong> tab → select <code>open-agent-ai-security</code> → <strong>enable auto-update</strong>. Claude Code then checks for a newer version <strong>at startup</strong> (not on a schedule) and updates automatically.</li>
+<li><strong>Fleet-wide (admins)</strong> — in managed <code>settings.json</code>:</li>
+</ul>
+<p><code>json
+  {
+    "extraKnownMarketplaces": {
+      "open-agent-ai-security": {
+        "source": { "source": "github", "repo": "open-agent-ai-security/praxen" },
+        "autoUpdate": true
+      }
+    }
+  }</code></p>
+<ul>
+<li><strong>Global override (env vars):</strong> <code>DISABLE_AUTOUPDATER=1</code> turns off <em>all</em> auto-updates; add <code>FORCE_AUTOUPDATE_PLUGINS=1</code> alongside it to keep plugin auto-updates while disabling Claude Code's own self-update.</li>
+</ul>
+<blockquote>
+<p>Because Praxen is a security tool, staying current matters — enabling auto-update (or updating on a regular cadence) is recommended.</p>
+</blockquote>
+<h3 id="openai-codex-unzipped-release">OpenAI Codex / unzipped release</h3>
+<p>There's no marketplace, so updating is manual: <code>git pull</code> the checkout (a symlinked skill folder picks up the new version automatically), or download the new release zip and replace it. There's no migration step; Praxen is stateless across analyses.</p>
 <h2 id="uninstalling">Uninstalling</h2>
 <p><strong>Claude Code (plugin marketplace):</strong></p>
 <pre><code class="language-bash">claude plugin uninstall praxen@open-agent-ai-security


### PR DESCRIPTION
The Updating section only listed the manual commands. Expand it to answer the common "how do I stay current / can it auto-update?" question.

- **Manual update** — the two-step `marketplace update` + `plugin update` flow, restart, and why skipping the catalog refresh leaves you on a stale cache.
- **Auto-update (opt-in)** — it's a **per-marketplace** setting, **off by default** for third-party marketplaces like ours, and **no notifications** fire. Documents the interactive toggle (`/plugin` → Marketplaces → enable auto-update), the fleet-wide `extraKnownMarketplaces … autoUpdate: true` managed setting, and the `DISABLE_AUTOUPDATER` / `FORCE_AUTOUPDATE_PLUGINS` env overrides.
- **Codex** — `git pull` / replace-zip, unchanged.

Docs only; regenerated `guide/installation.html`. RC-safe.