### PR TITLE
Promote dev → main: Cloudflare Web Analytics A/B (#123)

### DIFF
--- a/docs_build.py
+++ b/docs_build.py
@@ -177,9 +177,12 @@ def page_html(theme_css: str, title: str, nav: str, body: str, src: str, body_en
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{html.escape(title)} · Praxen Docs</title>
 <style>{theme_css}</style>
-<!-- Privacy-friendly, cookieless analytics (GoatCounter) — docs/landing pages only, never the reports.
-     count.js is self-hosted (assets/count.js, ISC) so no third-party executable JS runs on the page; only data posts to the GoatCounter endpoint. -->
+<!-- Cookieless web analytics — docs/landing pages only, never the reports.
+     Two tools run side by side (temporary A/B comparison):
+     (1) GoatCounter — self-hosted count.js (../assets/count.js, ISC); only data posts to the endpoint.
+     (2) Cloudflare Web Analytics — a third-party beacon from static.cloudflareinsights.com. -->
 <script data-goatcounter="https://open-agent-ai-security.goatcounter.com/count" async src="../assets/count.js"></script>
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{{"token": "223642421cad463daf91bd9429a5f9a0"}}'></script>
 </head>
 <body class="docs-page">
 <header class="docs-top">

--- a/guide/RAISE.html
+++ b/guide/RAISE.html
@@ -223,9 +223,12 @@ img { max-width: 100%; display: block; }
   .docs-main { padding-top: 26px; }
 }
 </style>
-<!-- Privacy-friendly, cookieless analytics (GoatCounter) — docs/landing pages only, never the reports.
-     count.js is self-hosted (assets/count.js, ISC) so no third-party executable JS runs on the page; only data posts to the GoatCounter endpoint. -->
+<!-- Cookieless web analytics — docs/landing pages only, never the reports.
+     Two tools run side by side (temporary A/B comparison):
+     (1) GoatCounter — self-hosted count.js (../assets/count.js, ISC); only data posts to the endpoint.
+     (2) Cloudflare Web Analytics — a third-party beacon from static.cloudflareinsights.com. -->
 <script data-goatcounter="https://open-agent-ai-security.goatcounter.com/count" async src="../assets/count.js"></script>
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "223642421cad463daf91bd9429a5f9a0"}'></script>
 </head>
 <body class="docs-page">
 <header class="docs-top">

--- a/guide/abv.html
+++ b/guide/abv.html
@@ -223,9 +223,12 @@ img { max-width: 100%; display: block; }
   .docs-main { padding-top: 26px; }
 }
 </style>
-<!-- Privacy-friendly, cookieless analytics (GoatCounter) — docs/landing pages only, never the reports.
-     count.js is self-hosted (assets/count.js, ISC) so no third-party executable JS runs on the page; only data posts to the GoatCounter endpoint. -->
+<!-- Cookieless web analytics — docs/landing pages only, never the reports.
+     Two tools run side by side (temporary A/B comparison):
+     (1) GoatCounter — self-hosted count.js (../assets/count.js, ISC); only data posts to the endpoint.
+     (2) Cloudflare Web Analytics — a third-party beacon from static.cloudflareinsights.com. -->
 <script data-goatcounter="https://open-agent-ai-security.goatcounter.com/count" async src="../assets/count.js"></script>
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "223642421cad463daf91bd9429a5f9a0"}'></script>
 </head>
 <body class="docs-page">
 <header class="docs-top">

--- a/guide/challenging-findings.html
+++ b/guide/challenging-findings.html
@@ -223,9 +223,12 @@ img { max-width: 100%; display: block; }
   .docs-main { padding-top: 26px; }
 }
 </style>
-<!-- Privacy-friendly, cookieless analytics (GoatCounter) — docs/landing pages only, never the reports.
-     count.js is self-hosted (assets/count.js, ISC) so no third-party executable JS runs on the page; only data posts to the GoatCounter endpoint. -->
+<!-- Cookieless web analytics — docs/landing pages only, never the reports.
+     Two tools run side by side (temporary A/B comparison):
+     (1) GoatCounter — self-hosted count.js (../assets/count.js, ISC); only data posts to the endpoint.
+     (2) Cloudflare Web Analytics — a third-party beacon from static.cloudflareinsights.com. -->
 <script data-goatcounter="https://open-agent-ai-security.goatcounter.com/count" async src="../assets/count.js"></script>
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "223642421cad463daf91bd9429a5f9a0"}'></script>
 </head>
 <body class="docs-page">
 <header class="docs-top">

--- a/guide/index.html
+++ b/guide/index.html
@@ -223,9 +223,12 @@ img { max-width: 100%; display: block; }
   .docs-main { padding-top: 26px; }
 }
 </style>
-<!-- Privacy-friendly, cookieless analytics (GoatCounter) — docs/landing pages only, never the reports.
-     count.js is self-hosted (assets/count.js, ISC) so no third-party executable JS runs on the page; only data posts to the GoatCounter endpoint. -->
+<!-- Cookieless web analytics — docs/landing pages only, never the reports.
+     Two tools run side by side (temporary A/B comparison):
+     (1) GoatCounter — self-hosted count.js (../assets/count.js, ISC); only data posts to the endpoint.
+     (2) Cloudflare Web Analytics — a third-party beacon from static.cloudflareinsights.com. -->
 <script data-goatcounter="https://open-agent-ai-security.goatcounter.com/count" async src="../assets/count.js"></script>
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "223642421cad463daf91bd9429a5f9a0"}'></script>
 </head>
 <body class="docs-page">
 <header class="docs-top">

--- a/guide/installation.html
+++ b/guide/installation.html
@@ -223,9 +223,12 @@ img { max-width: 100%; display: block; }
   .docs-main { padding-top: 26px; }
 }
 </style>
-<!-- Privacy-friendly, cookieless analytics (GoatCounter) — docs/landing pages only, never the reports.
-     count.js is self-hosted (assets/count.js, ISC) so no third-party executable JS runs on the page; only data posts to the GoatCounter endpoint. -->
+<!-- Cookieless web analytics — docs/landing pages only, never the reports.
+     Two tools run side by side (temporary A/B comparison):
+     (1) GoatCounter — self-hosted count.js (../assets/count.js, ISC); only data posts to the endpoint.
+     (2) Cloudflare Web Analytics — a third-party beacon from static.cloudflareinsights.com. -->
 <script data-goatcounter="https://open-agent-ai-security.goatcounter.com/count" async src="../assets/count.js"></script>
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "223642421cad463daf91bd9429a5f9a0"}'></script>
 </head>
 <body class="docs-page">
 <header class="docs-top">

--- a/guide/interpreting-reports.html
+++ b/guide/interpreting-reports.html
@@ -223,9 +223,12 @@ img { max-width: 100%; display: block; }
   .docs-main { padding-top: 26px; }
 }
 </style>
-<!-- Privacy-friendly, cookieless analytics (GoatCounter) — docs/landing pages only, never the reports.
-     count.js is self-hosted (assets/count.js, ISC) so no third-party executable JS runs on the page; only data posts to the GoatCounter endpoint. -->
+<!-- Cookieless web analytics — docs/landing pages only, never the reports.
+     Two tools run side by side (temporary A/B comparison):
+     (1) GoatCounter — self-hosted count.js (../assets/count.js, ISC); only data posts to the endpoint.
+     (2) Cloudflare Web Analytics — a third-party beacon from static.cloudflareinsights.com. -->
 <script data-goatcounter="https://open-agent-ai-security.goatcounter.com/count" async src="../assets/count.js"></script>
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "223642421cad463daf91bd9429a5f9a0"}'></script>
 </head>
 <body class="docs-page">
 <header class="docs-top">

--- a/guide/owasp.html
+++ b/guide/owasp.html
@@ -223,9 +223,12 @@ img { max-width: 100%; display: block; }
   .docs-main { padding-top: 26px; }
 }
 </style>
-<!-- Privacy-friendly, cookieless analytics (GoatCounter) — docs/landing pages only, never the reports.
-     count.js is self-hosted (assets/count.js, ISC) so no third-party executable JS runs on the page; only data posts to the GoatCounter endpoint. -->
+<!-- Cookieless web analytics — docs/landing pages only, never the reports.
+     Two tools run side by side (temporary A/B comparison):
+     (1) GoatCounter — self-hosted count.js (../assets/count.js, ISC); only data posts to the endpoint.
+     (2) Cloudflare Web Analytics — a third-party beacon from static.cloudflareinsights.com. -->
 <script data-goatcounter="https://open-agent-ai-security.goatcounter.com/count" async src="../assets/count.js"></script>
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "223642421cad463daf91bd9429a5f9a0"}'></script>
 </head>
 <body class="docs-page">
 <header class="docs-top">

--- a/guide/quickstart.html
+++ b/guide/quickstart.html
@@ -223,9 +223,12 @@ img { max-width: 100%; display: block; }
   .docs-main { padding-top: 26px; }
 }
 </style>
-<!-- Privacy-friendly, cookieless analytics (GoatCounter) — docs/landing pages only, never the reports.
-     count.js is self-hosted (assets/count.js, ISC) so no third-party executable JS runs on the page; only data posts to the GoatCounter endpoint. -->
+<!-- Cookieless web analytics — docs/landing pages only, never the reports.
+     Two tools run side by side (temporary A/B comparison):
+     (1) GoatCounter — self-hosted count.js (../assets/count.js, ISC); only data posts to the endpoint.
+     (2) Cloudflare Web Analytics — a third-party beacon from static.cloudflareinsights.com. -->
 <script data-goatcounter="https://open-agent-ai-security.goatcounter.com/count" async src="../assets/count.js"></script>
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "223642421cad463daf91bd9429a5f9a0"}'></script>
 </head>
 <body class="docs-page">
 <header class="docs-top">

--- a/guide/understanding-variability.html
+++ b/guide/understanding-variability.html
@@ -223,9 +223,12 @@ img { max-width: 100%; display: block; }
   .docs-main { padding-top: 26px; }
 }
 </style>
-<!-- Privacy-friendly, cookieless analytics (GoatCounter) — docs/landing pages only, never the reports.
-     count.js is self-hosted (assets/count.js, ISC) so no third-party executable JS runs on the page; only data posts to the GoatCounter endpoint. -->
+<!-- Cookieless web analytics — docs/landing pages only, never the reports.
+     Two tools run side by side (temporary A/B comparison):
+     (1) GoatCounter — self-hosted count.js (../assets/count.js, ISC); only data posts to the endpoint.
+     (2) Cloudflare Web Analytics — a third-party beacon from static.cloudflareinsights.com. -->
 <script data-goatcounter="https://open-agent-ai-security.goatcounter.com/count" async src="../assets/count.js"></script>
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "223642421cad463daf91bd9429a5f9a0"}'></script>
 </head>
 <body class="docs-page">
 <header class="docs-top">

--- a/guide/usage.html
+++ b/guide/usage.html
@@ -223,9 +223,12 @@ img { max-width: 100%; display: block; }
   .docs-main { padding-top: 26px; }
 }
 </style>
-<!-- Privacy-friendly, cookieless analytics (GoatCounter) — docs/landing pages only, never the reports.
-     count.js is self-hosted (assets/count.js, ISC) so no third-party executable JS runs on the page; only data posts to the GoatCounter endpoint. -->
+<!-- Cookieless web analytics — docs/landing pages only, never the reports.
+     Two tools run side by side (temporary A/B comparison):
+     (1) GoatCounter — self-hosted count.js (../assets/count.js, ISC); only data posts to the endpoint.
+     (2) Cloudflare Web Analytics — a third-party beacon from static.cloudflareinsights.com. -->
 <script data-goatcounter="https://open-agent-ai-security.goatcounter.com/count" async src="../assets/count.js"></script>
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "223642421cad463daf91bd9429a5f9a0"}'></script>
 </head>
 <body class="docs-page">
 <header class="docs-top">

--- a/guide/writing-remits.html
+++ b/guide/writing-remits.html
@@ -223,9 +223,12 @@ img { max-width: 100%; display: block; }
   .docs-main { padding-top: 26px; }
 }
 </style>
-<!-- Privacy-friendly, cookieless analytics (GoatCounter) — docs/landing pages only, never the reports.
-     count.js is self-hosted (assets/count.js, ISC) so no third-party executable JS runs on the page; only data posts to the GoatCounter endpoint. -->
+<!-- Cookieless web analytics — docs/landing pages only, never the reports.
+     Two tools run side by side (temporary A/B comparison):
+     (1) GoatCounter — self-hosted count.js (../assets/count.js, ISC); only data posts to the endpoint.
+     (2) Cloudflare Web Analytics — a third-party beacon from static.cloudflareinsights.com. -->
 <script data-goatcounter="https://open-agent-ai-security.goatcounter.com/count" async src="../assets/count.js"></script>
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "223642421cad463daf91bd9429a5f9a0"}'></script>
 </head>
 <body class="docs-page">
 <header class="docs-top">

--- a/index.html
+++ b/index.html
@@ -274,9 +274,12 @@
       .section-pad { padding: 56px 0; }
     }
   </style>
-  <!-- Privacy-friendly, cookieless analytics (GoatCounter) — docs/landing pages only, never the reports.
-       count.js is self-hosted (assets/count.js, ISC) so no third-party executable JS runs on the page; only data posts to the GoatCounter endpoint. -->
+  <!-- Cookieless web analytics — docs/landing pages only, never the reports.
+       Two tools run side by side (temporary A/B comparison):
+       (1) GoatCounter — self-hosted count.js (assets/count.js, ISC); only data posts to the endpoint.
+       (2) Cloudflare Web Analytics — a third-party beacon from static.cloudflareinsights.com. -->
   <script data-goatcounter="https://open-agent-ai-security.goatcounter.com/count" async src="assets/count.js"></script>
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "223642421cad463daf91bd9429a5f9a0"}'></script>
 </head>
 <body>
 

--- a/tests/render/test_render.py
+++ b/tests/render/test_render.py
@@ -150,7 +150,8 @@ def main():
     # into report_template.html.
     check("report HTML loads no external script / analytics beacon (self-contained, no phone-home)",
           re.search(r"<script\b[^>]*\bsrc\s*=", html, re.I) is None
-          and "goatcounter" not in html.lower() and "gc.zgo.at" not in html.lower())
+          and "goatcounter" not in html.lower() and "gc.zgo.at" not in html.lower()
+          and "cloudflareinsights" not in html.lower() and "beacon.min.js" not in html.lower())
 
     # 3. determinism
     out_html2 = os.path.join(tmp, "b.html")


### PR DESCRIPTION
Promotes the Cloudflare-Web-Analytics-alongside-GoatCounter change (#123) to `main` so it publishes on the Praxen Pages site.

- Adds the Cloudflare beacon next to GoatCounter on the landing page + all 11 `guide/*.html` (via `docs_build.py`).
- Hardens the report self-containment test to also reject Cloudflare beacons.
- Reports unaffected; 333 tests pass.

Merge as a **merge commit** (not squash) per the dev→main promotion convention; dev is then fast-forwarded to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)