### PR TITLE
Promote dev → main: Praxen 1.0.0 GA (#128)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Open Agent AI Security's Claude Code plugin marketplace. Currently publishes Praxen.",
-    "version": "1.0.0-rc.1"
+    "version": "1.0.0"
   },
   "plugins": [
     {
       "name": "praxen",
       "source": "./",
       "description": "Praxen \u2014 agent behavior verifier. Compares an agent's declared policy against the available evidence (source, deployment state, or behavioral artifacts); reports where observed behavior diverges from declared intent.",
-      "version": "1.0.0-rc.1",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "keywords": [
         "agent-behavior-verifier",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "praxen",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0",
   "description": "Praxen \u2014 agent behavior verifier. Compares an AI agent's declared policy (Worker Remit) against the available evidence \u2014 source code, live deployment state, or behavioral artifacts \u2014 and reports where observed behavior diverges from declared intent. Make sure your agent does its job \u2014 and only its job.",
   "author": {
     "name": "Exabeam",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "praxen",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0",
   "description": "Praxen \u2014 agent behavior verifier. Compares an AI agent's declared policy (Worker Remit) against the available evidence \u2014 source code, live deployment state, or behavioral artifacts \u2014 and reports where observed behavior diverges from declared intent. Make sure your agent does its job \u2014 and only its job.",
   "author": {
     "name": "Exabeam",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ All notable changes to Praxen will be recorded here. Format roughly follows [Kee
 
 _Nothing yet — staging the next change set._
 
+## [1.0.0] — 2026-06-19
+
+**Praxen 1.0 — general availability.** Promotes [`1.0.0-rc.1`](https://github.com/open-agent-ai-security/praxen/releases/tag/v1.0.0-rc.1) to the final `1.0.0` after its soak; the [1.0 stability contract](STABILITY.md) is now in force. The scan engine's *logic* is unchanged from the RC (and from `0.8.1`): `SKILL.md`, `schema.py`, `manifest_to_findings.py`, and the four knowledge bases are byte-identical, and `schema_version` stays `"2.0"`. The RC cleared a full **12-target regression suite** on Claude Opus 4.8; the GA engine is byte-identical to it, and a single-target FinBot sanity scan reproduced the committed baseline exactly (weighted RAISE 0.45 / 5.0, identical category vector, every canonical theme caught).
+
+### Added
+- **Real-world example — Salesforce Help Agent Accelerator** ([#77](https://github.com/open-agent-ai-security/praxen/pull/77)) — the first showcase scan against a real, shipping open-source product (vs. the deliberately-vulnerable training agents), contributed by [@rossja](https://github.com/rossja); listed in `examples/README.md`.
+
+### Changed
+- **Prose fields render rich** ([#114](https://github.com/open-agent-ai-security/praxen/pull/114)) — RAISE rationales, the executive/structure/behavior summaries, finding summaries, and What's-Working notes now render their inline `<code>`/`<strong>`/`<em>` markup (previously shown as literal tags), with a monospace inline-code "chip" style. `render.py` + `report_template.html` only — presentational; every committed baseline re-renders byte-identically from its unchanged JSON.
+
 ## [1.0.0-rc.1] — 2026-06-15
 
 **First 1.0 release candidate.** Ships the 1.0 stability contract, code-enforced security backstops, and an operator-UX docs pass — published as the **Latest** release on the default channel (pre-1.0 there is no separate "stable" channel; the newest candidate is what to install) so it can soak before the final `1.0.0`. The scan engine's *logic* is unchanged from `0.8.1` (`schema.py`, `manifest_to_findings.py`, and the four knowledge bases are byte-identical; `schema_version` stays `"2.0"`), and the candidate cleared a full **12-target regression suite** on Claude Opus 4.8 — all targets in-band against the `v0.7.7-claude48` baseline, no Critical theme dropped.

--- a/PRAXEN_SPEC.md
+++ b/PRAXEN_SPEC.md
@@ -5,7 +5,7 @@
 
 # Praxen — Specification
 
-**Version:** 1.0.0-rc.1
+**Version:** 1.0.0
 **Status:** Internal release
 **Tagline:** *Make sure your agent does its job — and only its job.*
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 **agent behavior verifier**
 
 [![CI](https://github.com/open-agent-ai-security/praxen/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agent-ai-security/praxen/actions/workflows/ci.yml)
-[![Latest release](https://img.shields.io/badge/release-v1.0.0--rc.1-blue)](https://github.com/open-agent-ai-security/praxen/releases)
+[![Latest release](https://img.shields.io/badge/release-v1.0.0-blue)](https://github.com/open-agent-ai-security/praxen/releases)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://www.python.org/downloads/)
 


### PR DESCRIPTION
Promotes the 1.0.0 GA version bump (#128) to `main` ahead of tagging `v1.0.0`.

- All six version-guarded locations now read `1.0.0`; `[1.0.0] — 2026-06-19` CHANGELOG entry.
- Engine byte-identical to `1.0.0-rc.1`; gates green (guard 17/17, render 333/333, plugin validate, build, FinBot sanity on-baseline).

Merge as a **merge commit** (not squash) per the dev→main convention; `dev` is then fast-forwarded to `main`. After this lands, `main` HEAD is tagged `v1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)