### PR TITLE
chore(release): scriptable post-tag plugin install smoke (primary check)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,9 +155,23 @@ a tag.
 2. Promote `dev → main` (merge commit, never squash), then fast-forward `dev`
    back up so `main` stays an ancestor of `dev`.
 3. Push the matching `v<version>` tag to fire `release.yml`.
-4. Verify the published release zip and run the post-tag marketplace install
-   check (`claude plugin marketplace add … && claude plugin install …`) on both
-   platforms — the manifest schema is not gated by CI.
+4. Verify the published release zip, then run the **post-tag plugin install
+   smoke** — a required step of every promotion. (It is deliberately *not* in
+   CI: the `claude` CLI is not run in GitHub Actions, so this stays a
+   maintainer-run check, and the manifest schema is otherwise ungated.)
+   - **Primary — the script:** `scripts/release/plugin-smoke.sh` (run after the
+     tag is pushed). It runs both real journeys against throwaway scratch
+     `$CLAUDE_CONFIG_DIR`s — a **clean install** from the GitHub marketplace and
+     an **upgrade** from the prior tag — and asserts the resulting version, never
+     touching your live install. Target/prior auto-resolve from `PRAXEN_SPEC.md`
+     and the most recent prior tag; override with
+     `scripts/release/plugin-smoke.sh v<target> v<prior>`.
+   - **Fallback — the manual commands it automates** (use if the script can't
+     run): in a scratch config,
+     `claude plugin marketplace add open-agent-ai-security/praxen && claude plugin install praxen@open-agent-ai-security && claude plugin list`
+     (expect the new version, enabled); for the upgrade leg, install the prior
+     tag first, then `claude plugin marketplace update … && claude plugin update …`.
+     Confirm the Codex symlink path surfaces the new version too.
 
 **Rolling back a bad release**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,18 +160,22 @@ a tag.
    CI: the `claude` CLI is not run in GitHub Actions, so this stays a
    maintainer-run check, and the manifest schema is otherwise ungated.)
    - **Primary — the script:** `scripts/release/plugin-smoke.sh` (run after the
-     tag is pushed). It runs both real journeys against throwaway scratch
-     `$CLAUDE_CONFIG_DIR`s — a **clean install** from the GitHub marketplace and
-     an **upgrade** from the prior tag — and asserts the resulting version, never
-     touching your live install. Target/prior auto-resolve from `PRAXEN_SPEC.md`
-     and the most recent prior tag; override with
-     `scripts/release/plugin-smoke.sh v<target> v<prior>`.
+     tag is pushed). It runs both real **Claude Code** journeys against throwaway
+     scratch `$CLAUDE_CONFIG_DIR`s — a **clean install** from the GitHub
+     marketplace and an **upgrade** from the prior tag — and asserts the
+     resulting version, never touching your live install. Target/prior
+     auto-resolve from `PRAXEN_SPEC.md` and the most recent prior tag; override
+     with `scripts/release/plugin-smoke.sh v<target> v<prior>`.
    - **Fallback — the manual commands it automates** (use if the script can't
      run): in a scratch config,
      `claude plugin marketplace add open-agent-ai-security/praxen && claude plugin install praxen@open-agent-ai-security && claude plugin list`
      (expect the new version, enabled); for the upgrade leg, install the prior
      tag first, then `claude plugin marketplace update … && claude plugin update …`.
-     Confirm the Codex symlink path surfaces the new version too.
+   - **Codex (always manual):** the script covers only the Claude Code
+     marketplace. Separately confirm the Codex skill-folder path surfaces the new
+     version — re-link / `git pull` (or re-unzip) and check `praxen:behavior-verifier`
+     resolves at `v<version>`. (Codex installs via a symlinked skill folder, not a
+     marketplace, so there is nothing for the script to drive.)
 
 **Rolling back a bad release**
 

--- a/scripts/release/plugin-smoke.sh
+++ b/scripts/release/plugin-smoke.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Copyright 2026 Exabeam, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Post-tag plugin install smoke for Praxen releases.
+#
+# This is the PRIMARY release-verification check for the two real install
+# journeys (clean install + upgrade). The equivalent hand-run `claude plugin …`
+# commands in CONTRIBUTING.md ("Releasing and rolling back") are the fallback if
+# this script can't run. It is intentionally NOT wired into CI: the `claude` CLI
+# is not run in GitHub Actions, so this stays a maintainer-run step.
+#
+# Both journeys run against isolated, throwaway $CLAUDE_CONFIG_DIR scratch dirs,
+# so your live Claude Code install is never touched.
+#
+#   scripts/release/plugin-smoke.sh [TARGET] [PRIOR_TAG]
+#
+#   TARGET     version or tag to verify   (default: the PRAXEN_SPEC.md version)
+#   PRIOR_TAG  tag to seed the upgrade from (default: most recently created other tag)
+#
+# Journeys:
+#   1. Clean install — add the GitHub marketplace + install; assert TARGET.
+#      Exercises the REAL published state (marketplace serves main@HEAD), so run
+#      this AFTER the dev→main promotion and the v<TARGET> tag are pushed.
+#   2. Upgrade       — seed PRIOR_TAG via a local git worktree, install it, then
+#      `marketplace update` + `plugin update`; assert it moves to TARGET.
+#
+# Requires: claude CLI, git, and network access (journey 1 clones the marketplace).
+# Exits non-zero on the first failed assertion.
+set -euo pipefail
+
+MARKET="open-agent-ai-security"        # marketplace name (from .claude-plugin/marketplace.json)
+PLUGIN="praxen@${MARKET}"
+REPO_SLUG="open-agent-ai-security/praxen"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+fail() { echo "  ✗ $*" >&2; exit 1; }
+command -v claude >/dev/null 2>&1 || fail "claude CLI not found on PATH"
+
+# --- resolve TARGET (strip a leading v) ---
+TARGET="${1:-}"
+[ -n "$TARGET" ] || TARGET="$(grep -m1 -E '^\*\*Version:\*\*' PRAXEN_SPEC.md \
+  | sed -E 's/.*\*\*Version:\*\*[[:space:]]*//; s/[[:space:]]*$//')"
+TARGET="${TARGET#v}"
+TARGET_TAG="v${TARGET}"
+
+# make sure release tags are present locally for the worktree checkout
+git fetch --tags --quiet origin 2>/dev/null || true
+git rev-parse -q --verify "refs/tags/${TARGET_TAG}" >/dev/null \
+  || fail "tag ${TARGET_TAG} not found — run this after pushing the release tag"
+
+# --- resolve PRIOR_TAG for the upgrade leg (most recent OTHER tag) ---
+PRIOR_TAG="${2:-}"
+[ -n "$PRIOR_TAG" ] || PRIOR_TAG="$(git tag --sort=-creatordate | grep -vxF "$TARGET_TAG" | head -1 || true)"
+
+# cleanup state
+SCRATCH=()
+WORKTREE=""
+cleanup() {
+  [ -n "$WORKTREE" ] && git worktree remove --force "$WORKTREE" >/dev/null 2>&1 || true
+  local d; for d in "${SCRATCH[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done
+}
+trap cleanup EXIT
+
+# read praxen's installed version from the current $CLAUDE_CONFIG_DIR
+installed_version() { claude plugin list 2>/dev/null | awk '/praxen@/{f=1} f&&/Version:/{print $2; exit}'; }
+assert_version() {
+  local want="$1" got; got="$(installed_version)"
+  [ "$got" = "$want" ] || fail "expected version '$want', got '${got:-<none>}'"
+  echo "  ✓ reports $got"
+}
+
+echo "=== Praxen plugin install smoke — target ${TARGET_TAG} ==="
+
+# ---------- Journey 1: clean install (new-user, real marketplace) ----------
+echo "[1/2] clean install from the GitHub marketplace (${REPO_SLUG})"
+CONFIG1="$(mktemp -d)"; SCRATCH+=("$CONFIG1")
+(
+  export CLAUDE_CONFIG_DIR="$CONFIG1"
+  claude plugin marketplace add "$REPO_SLUG" >/dev/null
+  claude plugin install "$PLUGIN" >/dev/null
+)
+CLAUDE_CONFIG_DIR="$CONFIG1" assert_version "$TARGET"
+
+# ---------- Journey 2: upgrade (prior tag -> target) ----------
+if [ -z "$PRIOR_TAG" ]; then
+  echo "[2/2] upgrade — SKIPPED (no prior tag found; first release?)"
+else
+  PRIOR_VER="${PRIOR_TAG#v}"
+  echo "[2/2] upgrade ${PRIOR_TAG} -> ${TARGET_TAG} (seeded via local worktree)"
+  CONFIG2="$(mktemp -d)"; SCRATCH+=("$CONFIG2")
+  WT_PARENT="$(mktemp -d)"; SCRATCH+=("$WT_PARENT")
+  WORKTREE="$WT_PARENT/praxen-prior"
+  git worktree add -q "$WORKTREE" "$PRIOR_TAG"
+  (
+    export CLAUDE_CONFIG_DIR="$CONFIG2"
+    claude plugin marketplace add "$WORKTREE" >/dev/null   # local marketplace @ PRIOR_TAG
+    claude plugin install "$PLUGIN" >/dev/null
+  )
+  CLAUDE_CONFIG_DIR="$CONFIG2" assert_version "$PRIOR_VER"
+  git -C "$WORKTREE" checkout -q "$TARGET_TAG"             # bump the marketplace source to GA
+  (
+    export CLAUDE_CONFIG_DIR="$CONFIG2"
+    claude plugin marketplace update "$MARKET" >/dev/null
+    claude plugin update "$PLUGIN" >/dev/null
+  )
+  CLAUDE_CONFIG_DIR="$CONFIG2" assert_version "$TARGET"
+fi
+
+echo "=== PASS — ${TARGET_TAG} installs clean and upgrades from ${PRIOR_TAG:-<none>} ==="

--- a/scripts/release/plugin-smoke.sh
+++ b/scripts/release/plugin-smoke.sh
@@ -53,14 +53,14 @@ git rev-parse -q --verify "refs/tags/${TARGET_TAG}" >/dev/null \
 
 # --- resolve PRIOR_TAG for the upgrade leg (most recent OTHER tag) ---
 PRIOR_TAG="${2:-}"
-[ -n "$PRIOR_TAG" ] || PRIOR_TAG="$(git tag --sort=-creatordate | grep -vxF "$TARGET_TAG" | head -1 || true)"
+[ -n "$PRIOR_TAG" ] || PRIOR_TAG="$(git tag -l 'v*' --sort=-creatordate | grep -vxF "$TARGET_TAG" | head -1 || true)"
 
 # cleanup state
 SCRATCH=()
 WORKTREE=""
 cleanup() {
   [ -n "$WORKTREE" ] && git worktree remove --force "$WORKTREE" >/dev/null 2>&1 || true
-  local d; for d in "${SCRATCH[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done
+  local d; for d in ${SCRATCH[@]+"${SCRATCH[@]}"}; do [ -n "$d" ] && rm -rf "$d"; done
 }
 trap cleanup EXIT
 
@@ -79,8 +79,8 @@ echo "[1/2] clean install from the GitHub marketplace (${REPO_SLUG})"
 CONFIG1="$(mktemp -d)"; SCRATCH+=("$CONFIG1")
 (
   export CLAUDE_CONFIG_DIR="$CONFIG1"
-  claude plugin marketplace add "$REPO_SLUG" >/dev/null
-  claude plugin install "$PLUGIN" >/dev/null
+  claude plugin marketplace add "$REPO_SLUG" >/dev/null </dev/null
+  claude plugin install "$PLUGIN" >/dev/null </dev/null
 )
 CLAUDE_CONFIG_DIR="$CONFIG1" assert_version "$TARGET"
 
@@ -96,15 +96,15 @@ else
   git worktree add -q "$WORKTREE" "$PRIOR_TAG"
   (
     export CLAUDE_CONFIG_DIR="$CONFIG2"
-    claude plugin marketplace add "$WORKTREE" >/dev/null   # local marketplace @ PRIOR_TAG
-    claude plugin install "$PLUGIN" >/dev/null
+    claude plugin marketplace add "$WORKTREE" >/dev/null </dev/null   # local marketplace @ PRIOR_TAG
+    claude plugin install "$PLUGIN" >/dev/null </dev/null
   )
   CLAUDE_CONFIG_DIR="$CONFIG2" assert_version "$PRIOR_VER"
   git -C "$WORKTREE" checkout -q "$TARGET_TAG"             # bump the marketplace source to GA
   (
     export CLAUDE_CONFIG_DIR="$CONFIG2"
-    claude plugin marketplace update "$MARKET" >/dev/null
-    claude plugin update "$PLUGIN" >/dev/null
+    claude plugin marketplace update "$MARKET" >/dev/null </dev/null
+    claude plugin update "$PLUGIN" >/dev/null </dev/null
   )
   CLAUDE_CONFIG_DIR="$CONFIG2" assert_version "$TARGET"
 fi


### PR DESCRIPTION
Makes the Phase-4 plugin install/reinstall verification — the manual `claude plugin …` check we run by hand at every release — **durable and repeatable** as a committed script, per the decision to keep `claude` out of CI.

### What it adds
- **`scripts/release/plugin-smoke.sh`** — runs both real user journeys against isolated, throwaway `$CLAUDE_CONFIG_DIR` scratch dirs (never the live install) and asserts the resulting plugin version:
  1. **Clean install** from the GitHub marketplace (new-user path).
  2. **Upgrade** from the prior tag → target, seeded via a local `git worktree` (`marketplace update` + `plugin update`).
  - Target/prior auto-resolve from `PRAXEN_SPEC.md` + the most recent prior tag; override with `plugin-smoke.sh v<target> v<prior>`. Exits non-zero on the first failed assertion.
- **`CONTRIBUTING.md`** — the release runbook's step 4 now names this script the **primary** post-tag check, with the hand-run commands kept as the **fallback**, and states it's a required step of every promotion (not gated by CI).

### Why not CI
Per decision: the `claude` CLI is not run in GitHub Actions. This stays a maintainer-run step; the script just makes it one command instead of a hand sequence.

### Verification
Ran against the live `v1.0.0` release: clean install → `1.0.0`, upgrade `v1.0.0-rc.1 → 1.0.0`, both **PASS**. `bash -n` clean.

Future-release hardening only — does not touch the shipped GA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)