### PR TITLE
docs(usage): refresh scan-time estimate (8–15 → 3–10 min, YMMV)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -207,7 +207,7 @@ A long scan can exceed the context window and **auto-compact mid-run** — silen
 
 ### Scan stopped emitting output for several minutes (streaming hiccup)
 
-Praxen scans typically take 8–15 minutes of wallclock; larger codebases scoped to a subdirectory sit at the high end. If a scan goes quiet for ~10 minutes with no progress messages or tool activity, you've likely hit a streaming hiccup — usually during the long-form drafting of the findings JSON. Symptoms:
+Praxen scans ran 3–10 minutes of wallclock across our test suite; larger codebases scoped to a subdirectory sit at the high end. Your mileage will vary — target size and scope, model tier, and provider capacity at the time all move the number. If a scan goes quiet for ~5 minutes with no progress messages or tool activity, you've likely hit a streaming hiccup — usually during the long-form drafting of the findings JSON. Symptoms:
 
 - The agent emitted an analysis plan and started drafting findings, then went silent mid-document.
 - No new files appear in the output directory; any partial JSON on disk is still valid but incomplete.

--- a/guide/usage.html
+++ b/guide/usage.html
@@ -411,7 +411,7 @@ behavior-verifier skill against the same workspace and remit, and factor these i
 </ul>
 <p>→ Prevention and recovery (a larger window, tighter scope, and the draft-manifest safety net) are covered in <a href="#large-workspaces-and-context-sizing">Large workspaces and context sizing</a> above.</p>
 <h3 id="scan-stopped-emitting-output-for-several-minutes-streaming-hiccup">Scan stopped emitting output for several minutes (streaming hiccup)</h3>
-<p>Praxen scans typically take 8–15 minutes of wallclock; larger codebases scoped to a subdirectory sit at the high end. If a scan goes quiet for ~10 minutes with no progress messages or tool activity, you've likely hit a streaming hiccup — usually during the long-form drafting of the findings JSON. Symptoms:</p>
+<p>Praxen scans ran 3–10 minutes of wallclock across our test suite; larger codebases scoped to a subdirectory sit at the high end. Your mileage will vary — target size and scope, model tier, and provider capacity at the time all move the number. If a scan goes quiet for ~5 minutes with no progress messages or tool activity, you've likely hit a streaming hiccup — usually during the long-form drafting of the findings JSON. Symptoms:</p>
 <ul>
 <li>The agent emitted an analysis plan and started drafting findings, then went silent mid-document.</li>
 <li>No new files appear in the output directory; any partial JSON on disk is still valid but incomplete.</li>


### PR DESCRIPTION
The "8–15 minutes of wallclock" claim in `docs/usage.md` is stale — scans are considerably faster now (our own tuning + provider capacity). The full **12-target suite on the shipped 1.0.0 engine** just ran **2.6–4.4 min/target** (mean 3.5), including the larger targets.

### Change (`docs/usage.md`, + regenerated `guide/usage.html`)
- "typically take **8–15 minutes**" → "ran **3–10 minutes** across our test suite" + explicit **YMMV** (target size/scope, model tier, provider capacity at the time).
- Streaming-hiccup stale-detection threshold **~10 min → ~5 min** — a whole scan now finishes in a few minutes, so 5 min of silence is the right "it's stuck" signal (10 min overlapped the top of the normal range).

The five "about five minutes" **quickstart** mentions (quickstart/index/abv/installation/README) are left as-is — that's the whole walkthrough (clone + run + open report), and FinBot's scan ran ~4.4 min here, so it's still accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)