### PR TITLE
docs(quickstart): rewrite around the author→scan→improve flow (5→15 min)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Each finding is tagged against the **OWASP Top 10 for LLM Applications 2025**, *
 ## Get started
 
 - [**Installation**](docs/installation.md) — Claude Code or OpenAI Codex (plugin / skill folder, or unzipped release)
-- [**Quickstart**](docs/quickstart.md) — your first end-to-end report in about five minutes: scan the FinBot agent (source cloned from upstream) against the bundled remit
+- [**Quickstart**](docs/quickstart.md) — your first end-to-end report in about 15 minutes: have Claude author a remit for the FinBot demo agent, scan it, and read the report
 - [**Writing Worker Remits**](docs/writing-remits.md) — authoring the policy document
 - [**Usage**](docs/usage.md) — running an analysis end-to-end
 - [**Interpreting Reports**](docs/interpreting-reports.md) — reading the HTML / JSON / TXT outputs

--- a/docs/abv.md
+++ b/docs/abv.md
@@ -121,7 +121,7 @@ As AI agents become operational actors inside business systems, *is this agent b
 
 ## Next steps
 
-- [Quickstart](quickstart.md) — first report against the bundled `finbot` example in five minutes
+- [Quickstart](quickstart.md) — have Claude author a remit for the FinBot demo agent, scan it, and read the report, in about 15 minutes
 - [Writing Worker Remits](writing-remits.md) — author the policy document ABV verifies against
 - [The RAISE Framework](RAISE.md) — the six-category maturity model Praxen scores
 - [Interpreting Reports](interpreting-reports.md) — how to read what Praxen produces

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@
 |---|---|
 | New to the concept and want the "why" | [What is Agent Behavior Verification?](abv.md) |
 | Setting up Praxen for the first time | [Installation](installation.md) |
-| Trying it out for the first time | [Quickstart](quickstart.md) — first report against the bundled `finbot` example in five minutes |
+| Trying it out for the first time | [Quickstart](quickstart.md) — have Claude author a remit for the FinBot demo agent, scan it, and read the report, in about 15 minutes |
 | Ready to run your first real analysis | [Usage](usage.md) |
 | Writing a Worker Remit for an agent | [Writing Worker Remits](writing-remits.md) |
 | Looking at a report and trying to understand it | [Interpreting Reports](interpreting-reports.md) |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -138,6 +138,6 @@ The marketplace is removed by its registered name (`open-agent-ai-security`, fro
 
 ## Next steps
 
-- [Quickstart](quickstart.md) — first end-to-end report: scan the FinBot agent (source cloned from upstream) against the bundled remit
+- [Quickstart](quickstart.md) — first end-to-end report: have Claude author a remit for the FinBot demo agent, scan it, and read the report
 - [Writing Worker Remits](writing-remits.md) — authoring the policy document Praxen verifies against
 - [Usage](usage.md) — the full running-an-analysis reference

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -74,7 +74,7 @@ If `praxen@open-agent-ai-security` appears at `v0.8.0` or later with `enabled`, 
 
 **Codex:** confirm the skill appears to the model as `praxen:behavior-verifier` in Codex's skill list. That's the parity check — it confirms discovery, the same way `claude plugin list` does for Claude Code.
 
-For the first **end-to-end run** on either platform — Worker Remit + agent source → HTML / JSON / TXT report — see [Quickstart](quickstart.md). It walks through scanning the FinBot agent (source cloned from upstream) against the bundled remit in about five minutes, with the exact Claude Code and Codex commands.
+For the first **end-to-end run** — declared intent → evidence → HTML / JSON / TXT report — see [Quickstart](quickstart.md). It walks through having Claude author a Worker Remit for the FinBot demo agent, scan the code against it, and read the report, in about 15 minutes — all from plain-English instructions.
 
 ## Updating
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,112 +3,96 @@
   SPDX-License-Identifier: Apache-2.0
 -->
 
-# Quickstart — your first Praxen report in five minutes
+# Quickstart — your first Praxen report in about 15 minutes
 
-This walks you from "Praxen is installed" to "I have a real report" against **FinBot**, a deliberately vulnerable invoice-processing agent from the OWASP Agentic AI CTF. No editing your own agent required. (FinBot is small, so five minutes is realistic; a real-world target typically takes longer — see [Usage](usage.md).)
+A complete Praxen run, end to end: you'll have Claude **author a security policy** for a real agent, **verify the agent's code against it**, and read the report — all from plain-English instructions. The target is **FinBot**, a deliberately vulnerable invoice-processing agent from the OWASP Agentic AI CTF, so the divergences are dramatic and easy to learn from.
 
-Every Praxen scan needs **two separate inputs**: a **Worker Remit** (the policy) and a **separate agent source tree** (the evidence). Here you'll use the bundled FinBot remit and clone FinBot's source from upstream. The `examples/finbot/` report files are the *reference output* — what your run should approximately produce — **not** the thing you scan.
+You do very little here — four short instructions; Claude does the work: fetching docs, writing the policy, cloning the code, running the analysis, and rendering the report. Budget about 15 minutes, most of it Claude thinking while you watch.
 
-If you haven't installed yet, do [Installation](installation.md) first — one marketplace command on Claude Code, or a one-line skill link on Codex.
+> Not installed yet? Do [Installation](installation.md) first — one marketplace command on Claude Code, or a one-line skill link on Codex. There's nothing else to clone or download; Claude pulls what it needs.
 
-## 1. Get a copy of the Praxen repository
+## Set up
 
-If you don't have a local copy of the Praxen repository yet, clone it:
-
-```bash
-git clone https://github.com/open-agent-ai-security/praxen.git
-cd praxen
-```
-
-The only thing you'll take from `examples/finbot/` is the **remit** — the rest of that folder is the reference report:
-
-```
-examples/finbot/
-  WORKER_REMIT.md          ← the policy doc you'll verify against  (the one input you use)
-  finbot-analysis.html     ← reference report — what your run should approximately produce (NOT a scan target)
-  finbot-findings.json     ← the same reference findings, as JSON                          (NOT a scan target)
-```
-
-You'll get the *other* input — the agent source to scan — by cloning FinBot from upstream in the next step. A real first scan would use *your* agent's source plus a remit you wrote; we're using the pre-staged remit so the first run has no moving parts.
-
-## 2. Get the FinBot source
-
-The example was developed against the **CineFlow Productions finbot** from the OWASP Agentic AI CTF (see [`examples/README.md`](../examples/README.md) for the full provenance). Clone the source so Praxen has a real workspace to read:
+Start a Claude Code session in a fresh, empty folder — that's where the remit and the `reports/` will land:
 
 ```bash
-git clone https://github.com/OWASP-ASI/finbot-ctf-demo.git ../finbot-src
+mkdir finbot-quickstart && cd finbot-quickstart
+claude
 ```
 
-(Any directory will do — `../finbot-src` keeps the clone outside the Praxen tree and works the same on macOS, Linux, and Windows.)
+As you go, Claude will ask permission to do things like clone the repo, write the remit, and run the renderer — approve them.
 
-## 3. Run the analysis
+## 1. Have Claude author the Worker Remit
 
-From a Claude Code session in the `praxen` repo directory, ask the agent:
+A Praxen scan checks an agent against a **Worker Remit** — a plain-language policy of what the agent is *supposed* to do. Rather than hand-write one, have Claude do it:
 
-```
-Please run the behavior-verifier skill against ../finbot-src.
-Use the Worker Remit at examples/finbot/WORKER_REMIT.md. Write outputs
-to ./reports/finbot-quickstart/.
-```
+> *Author a Worker Remit for this agent from its repo docs. It's an intentionally vulnerable bot, so build the remit from the **intended** ("desired") behavior in the docs — don't read the implementation code: https://github.com/OWASP-ASI/finbot-ctf-demo*
 
-**On Codex** the flow is identical. After the one-time user-wide skill link ([Installation](installation.md#option-b--openai-codex-agent-skill) Option B), run the same request via `codex exec` from the `praxen` repo directory:
+**What Claude does:** loads the Praxen skill, reads the repo's README and design/walkthrough docs (not the code), and — because FinBot's docs are an *attack* walkthrough — inverts each documented exploit into the secure behavior it violates. It writes `WORKER_REMIT.md` and appends a short **Open Questions** list for what it can't infer (the real approval thresholds, whether vendors are allowlisted, whether MFA is required). A couple of minutes.
 
-```bash
-codex exec --sandbox workspace-write -C "$(pwd)" \
-  'Use $praxen:behavior-verifier. Run a Praxen behavior analysis against ../finbot-src. Use the Worker Remit at examples/finbot/WORKER_REMIT.md. Write outputs to ./reports/finbot-quickstart/.'
-```
+**Why "don't read the code" matters:** the remit is the standard the scan judges the code against. If you author it *from* the implementation, it just mirrors what the code already does — and the scan finds nothing. Building it from stated intent is what gives the scan something real to measure against. (This discipline is built into the skill; see [Writing Worker Remits](writing-remits.md).) Skim `WORKER_REMIT.md` — it's your policy, and you can tighten it or answer the Open Questions before scanning if you want a sharper result.
 
-That's the whole prompt. Praxen will:
+## 2. Have Claude run the scan
 
-1. Read the Worker Remit
-2. Sweep the workspace at `../finbot-src`
-3. Score the six RAISE categories
-4. Audit every remit rule
-5. Surface compound attack chains
-6. Write three files to `./reports/finbot-quickstart/` (plus a working draft checkpoint it may clean up)
+Now point Praxen at the agent's actual code, using the remit it just wrote:
 
-The skill prints an interim overview to stdout while it works. When it finishes you'll have:
+> *Run the scan now, using the remit you built.*
 
-```
-./reports/finbot-quickstart/
-  finbot-findings-YYYY-MM-DD.json     ← canonical record
-  finbot-analysis-YYYY-MM-DD-HHMMSS.html  ← human-readable report
-  finbot-analysis-YYYY-MM-DD-HHMMSS.txt   ← plain-text summary
-```
+**What Claude does:** clones FinBot itself, sweeps the workspace, scores the six RAISE categories, audits every remit rule, checkpoints the analysis to a draft manifest (so a long run survives a context-window compaction), and renders the report. Several minutes — this is the long pole of the run.
 
-## 4. Open the report
+**What you'll see:** FinBot lands at a RAISE posture of **"Absent"** — a near-floor score, expected for a deliberately-broken agent — with a dozen-plus findings, **Criticals first**. The headline is a compound chain: an unauthenticated admin plane → attacker text written into the agent's goals → no approval gate on payments → no audit log — the exact goal-hijack-to-autonomous-payment path the CTF is built around. It also notes what FinBot gets *right* (no code-execution capability, a bounded agent loop), so the report isn't only a list of failures.
 
-```bash
-open ./reports/finbot-quickstart/finbot-analysis-*.html
-```
+*(Exact counts and the score shift from run to run — synthesis is an act of judgment, not a fixed function. The themes are the stable signal; see [Run-to-Run Variability](understanding-variability.md).)*
 
-(`open` is macOS; on Linux use `xdg-open`, on Windows the file works in any browser.)
+## 3. Read the report
 
-What you should see, top to bottom:
+> *Show me the report in the browser.*
 
-- A red **CRITICAL** status badge — FinBot is deliberately broken
-- An **Agent Remit** panel restating what the remit says, alongside an **Agent Structure** panel summarising what Praxen found in the workspace
-- A **Behavior Summary** — the dominant pattern (typically something like *"framework offers safe primitives, code uses none of them"*)
-- A **Remit Coverage** table listing every rule with status (`Verified` / `Gap` / `Partial` / `Vague` / `ENP`)
-- A **Findings Register** — Critical first, then High, Medium, Low, Informational, each with evidence and a recommended action
-- A **RAISE Maturity Posture** wrap-up — a 0–5 weighted score across six categories
+Claude opens the self-contained HTML report. Read it top to bottom:
 
-You can compare your fresh report against the [published FinBot example report](https://open-agent-ai-security.github.io/praxen/examples/finbot/finbot-analysis.html) (rendered on GitHub Pages). It won't be byte-identical (LLM analyses have run-to-run variance) but the dominant Critical themes, the broad RAISE shape, and the remit-coverage counts should be close. See [tests/README.md](../tests/README.md) for what "close" actually means for this target.
+- **Behavior Summary + RAISE scorecard** — the one-line story (something like *"safe primitives offered, none used"*) and the 0–5 weighted maturity score across six categories, color-graded by score.
+- **Findings register** — Critical first, then High → Informational. Each card carries its **`file:line` evidence** and the **remit rule(s) it violates**, plus a recommended action.
+- **Remit Coverage table** — every rule you authored, marked `Verified` / `Gap` / `Partial` / `Vague` / `ENP` (exists-not-proven). This is where you see how much of your policy the code actually honors.
+- **OWASP heatmaps** + **Positives** — the findings mapped to the OWASP LLM and Agentic risk catalogs, and the controls that *are* present and working.
 
-## 5. Now try your own agent
+Ask Claude to walk through any finding — *"explain PRAX-005"*, *"why is this Critical?"* — and it re-examines the evidence with you. The analysis is conversational, so you can challenge or revise it; see [Challenging and Revising Findings](challenging-findings.md).
 
-The pattern is identical with a real target:
+## Bonus — don't just measure, improve
 
-1. [Write a Worker Remit](writing-remits.md) for the agent
-2. Point Praxen at whatever evidence you have — source, deployment files, behavioral logs, governance docs
-3. Read the report; [iterate](challenging-findings.md) on the remit and the agent as needed
+At this point Praxen has done its core job: you have a report that tells you exactly where FinBot diverges from its remit. But a verifier that only measures is half a tool. A Praxen finding isn't just a label — it carries `file:line` evidence and a recommended action — so it's something you can act on. Close the loop.
+
+Ask Claude to fix the worst one:
+
+> *Find the most critical finding and create a fix.*
+
+**What Claude does:** it identifies the highest-priority finding, targets a fix in the agent's code, verifies the change, and reports back what it changed and what's still open. Which finding it leads with and how it fixes it will vary — that's a judgment call on a live codebase — but the shape is consistent: one concrete, load-bearing fix, verified, not a vague to-do list.
+
+*In one run, for example,* it targeted FinBot's missing payment-approval gate, added a deterministic check that routes high-value or manipulation-flagged invoices to human review before any payment, then verified it end-to-end — running a manipulated "CEO-approved, $25k, urgent" invoice through the real decision path and confirming it now stops at review while clean invoices still pass.
+
+Now re-verify — run the same loop again:
+
+> *Re-run the Praxen scan and show me what changed.*
+
+The finding you fixed should resolve or downgrade, its remit rule should move toward `Verified`, and the RAISE posture should tick up. It won't jump to green — FinBot has plenty more deliberate holes, and the report now points you at the next one. That's the model: **measure → remediate → re-verify**, one link at a time, with the report as your worklist.
+
+That loop — verify intent, fix the divergence, prove the fix landed — is the whole idea. Praxen doesn't just tell you an agent is unsafe; it hands you an actionable, re-checkable path to making it safe.
+
+## Now point it at your own agent
+
+Same moves, your target:
+
+1. Ask Claude to **author a remit** from your agent's docs and intended behavior (or [write one yourself](writing-remits.md))
+2. Ask it to **scan** your agent's evidence against it — source, deployment files, behavioral logs, governance docs
+3. **Read** the report, then [iterate](challenging-findings.md) on the remit and the agent
 
 See [Usage](usage.md) for the full set of input shapes and the running-an-analysis details.
+
+> **Want a fixed, repeatable result** — a regression baseline rather than a tutorial? Use a pinned remit instead of authoring one each time. The bundled `examples/finbot/WORKER_REMIT.md` and its [reference report](https://open-agent-ai-security.github.io/praxen/examples/finbot/finbot-analysis.html) are exactly that; see [tests/README.md](../tests/README.md).
 
 ## If something went wrong
 
 See the [Troubleshooting](usage.md#troubleshooting) section in `usage.md`. The most common first-run snags:
 
 - **"behavior-verifier skill not found"** — restart Claude Code or run `/reload-plugins`
-- **`render.py` errored at the end** — the LLM produced a malformed findings JSON; re-run with more context window or a more focused workspace path
-- **Context window auto-compacted during the run** — Praxen wrote a draft manifest in `./reports/<agent-slug>-draft-<timestamp>.md`; tell the agent to read it and finish from there. See [Usage § Large workspaces and context sizing](usage.md#large-workspaces-and-context-sizing).
+- **`render.py` errored at the end** — the model produced malformed findings JSON; ask Claude to re-render from the draft manifest it wrote, or re-run with a tighter workspace path
+- **Context window auto-compacted during the run** — Praxen wrote a draft manifest at `./reports/<agent-slug>-draft-<timestamp>.md`; tell Claude to read it and finish the report from there. See [Usage § Large workspaces and context sizing](usage.md#large-workspaces-and-context-sizing).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,6 +13,8 @@ You do very little here — four short instructions; Claude does the work: fetch
 
 ## Set up
 
+This walkthrough uses **Claude Code**; **OpenAI Codex** works the same way. Wherever it says `claude` or "ask Claude," substitute your Codex invocation — `$praxen:behavior-verifier` run via `codex exec` (see [Installation](installation.md#option-b--openai-codex-agent-skill)) — and the four plain-English requests below work unchanged.
+
 Start a Claude Code session in a fresh, empty folder — that's where the remit and the `reports/` will land:
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,13 +7,13 @@
 
 A complete Praxen run, end to end: you'll have Claude **author a security policy** for a real agent, **verify the agent's code against it**, and read the report — all from plain-English instructions. The target is **FinBot**, a deliberately vulnerable invoice-processing agent from the OWASP Agentic AI CTF, so the divergences are dramatic and easy to learn from.
 
+This walkthrough uses **Claude Code**; **OpenAI Codex** works the same way — wherever it says `claude` or "ask Claude," substitute your Codex invocation, and the steps are identical.
+
 You do very little here — four short instructions; Claude does the work: fetching docs, writing the policy, cloning the code, running the analysis, and rendering the report. Budget about 15 minutes, most of it Claude thinking while you watch.
 
 > Not installed yet? Do [Installation](installation.md) first — one marketplace command on Claude Code, or a one-line skill link on Codex. There's nothing else to clone or download; Claude pulls what it needs.
 
 ## Set up
-
-This walkthrough uses **Claude Code**; **OpenAI Codex** works the same way. Wherever it says `claude` or "ask Claude," substitute your Codex invocation, and the four plain-English requests below work unchanged.
 
 Start a Claude Code session in a fresh, empty folder — that's where the remit and the `reports/` will land:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,7 +13,7 @@ You do very little here — four short instructions; Claude does the work: fetch
 
 ## Set up
 
-This walkthrough uses **Claude Code**; **OpenAI Codex** works the same way. Wherever it says `claude` or "ask Claude," substitute your Codex invocation — `$praxen:behavior-verifier` run via `codex exec` (see [Installation](installation.md#option-b--openai-codex-agent-skill)) — and the four plain-English requests below work unchanged.
+This walkthrough uses **Claude Code**; **OpenAI Codex** works the same way. Wherever it says `claude` or "ask Claude," substitute your Codex invocation, and the four plain-English requests below work unchanged.
 
 Start a Claude Code session in a fresh, empty folder — that's where the remit and the `reports/` will land:
 

--- a/guide/abv.html
+++ b/guide/abv.html
@@ -332,7 +332,7 @@ img { max-width: 100%; display: block; }
 <p>As AI agents become operational actors inside business systems, <em>is this agent behaving as authorized?</em> becomes one of the most important security questions an organization can ask.</p>
 <h2 id="next-steps">Next steps</h2>
 <ul>
-<li><a href="quickstart.html">Quickstart</a> — first report against the bundled <code>finbot</code> example in five minutes</li>
+<li><a href="quickstart.html">Quickstart</a> — have Claude author a remit for the FinBot demo agent, scan it, and read the report, in about 15 minutes</li>
 <li><a href="writing-remits.html">Writing Worker Remits</a> — author the policy document ABV verifies against</li>
 <li><a href="RAISE.html">The RAISE Framework</a> — the six-category maturity model Praxen scores</li>
 <li><a href="interpreting-reports.html">Interpreting Reports</a> — how to read what Praxen produces</li>

--- a/guide/index.html
+++ b/guide/index.html
@@ -268,7 +268,7 @@ img { max-width: 100%; display: block; }
 </tr>
 <tr>
 <td>Trying it out for the first time</td>
-<td><a href="quickstart.html">Quickstart</a> — first report against the bundled <code>finbot</code> example in five minutes</td>
+<td><a href="quickstart.html">Quickstart</a> — have Claude author a remit for the FinBot demo agent, scan it, and read the report, in about 15 minutes</td>
 </tr>
 <tr>
 <td>Ready to run your first real analysis</td>

--- a/guide/installation.html
+++ b/guide/installation.html
@@ -288,7 +288,7 @@ cd praxen-VERSION
 </code></pre>
 <p>If <code>praxen@open-agent-ai-security</code> appears at <code>v0.8.0</code> or later with <code>enabled</code>, the marketplace install is working. From within a session the same plugin shows under <code>/plugin list</code>, and the skill is invocable as <code>behavior-verifier</code>.</p>
 <p><strong>Codex:</strong> confirm the skill appears to the model as <code>praxen:behavior-verifier</code> in Codex's skill list. That's the parity check — it confirms discovery, the same way <code>claude plugin list</code> does for Claude Code.</p>
-<p>For the first <strong>end-to-end run</strong> on either platform — Worker Remit + agent source → HTML / JSON / TXT report — see <a href="quickstart.html">Quickstart</a>. It walks through scanning the FinBot agent (source cloned from upstream) against the bundled remit in about five minutes, with the exact Claude Code and Codex commands.</p>
+<p>For the first <strong>end-to-end run</strong> — declared intent → evidence → HTML / JSON / TXT report — see <a href="quickstart.html">Quickstart</a>. It walks through having Claude author a Worker Remit for the FinBot demo agent, scan the code against it, and read the report, in about 15 minutes — all from plain-English instructions.</p>
 <h2 id="updating">Updating</h2>
 <p>Every Praxen release bumps the version string, so a new version is always picked up once you refresh — the only question is whether you refresh by hand or let Claude Code do it for you. Check what you currently have with:</p>
 <pre><code class="language-bash">claude plugin list      # shows praxen@open-agent-ai-security and its installed version

--- a/guide/installation.html
+++ b/guide/installation.html
@@ -332,7 +332,7 @@ claude plugin marketplace remove open-agent-ai-security
 <p><strong>Unzipped release:</strong> delete the directory. No system state is left behind.</p>
 <h2 id="next-steps">Next steps</h2>
 <ul>
-<li><a href="quickstart.html">Quickstart</a> — first end-to-end report: scan the FinBot agent (source cloned from upstream) against the bundled remit</li>
+<li><a href="quickstart.html">Quickstart</a> — first end-to-end report: have Claude author a remit for the FinBot demo agent, scan it, and read the report</li>
 <li><a href="writing-remits.html">Writing Worker Remits</a> — authoring the policy document Praxen verifies against</li>
 <li><a href="usage.html">Usage</a> — the full running-an-analysis reference</li>
 </ul></article>

--- a/guide/quickstart.html
+++ b/guide/quickstart.html
@@ -250,7 +250,7 @@ img { max-width: 100%; display: block; }
 <p>Not installed yet? Do <a href="installation.html">Installation</a> first — one marketplace command on Claude Code, or a one-line skill link on Codex. There's nothing else to clone or download; Claude pulls what it needs.</p>
 </blockquote>
 <h2 id="set-up">Set up</h2>
-<p>This walkthrough uses <strong>Claude Code</strong>; <strong>OpenAI Codex</strong> works the same way. Wherever it says <code>claude</code> or "ask Claude," substitute your Codex invocation — <code>$praxen:behavior-verifier</code> run via <code>codex exec</code> (see <a href="installation.html#option-b--openai-codex-agent-skill">Installation</a>) — and the four plain-English requests below work unchanged.</p>
+<p>This walkthrough uses <strong>Claude Code</strong>; <strong>OpenAI Codex</strong> works the same way. Wherever it says <code>claude</code> or "ask Claude," substitute your Codex invocation, and the four plain-English requests below work unchanged.</p>
 <p>Start a Claude Code session in a fresh, empty folder — that's where the remit and the <code>reports/</code> will land:</p>
 <pre><code class="language-bash">mkdir finbot-quickstart &amp;&amp; cd finbot-quickstart
 claude

--- a/guide/quickstart.html
+++ b/guide/quickstart.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Quickstart — your first Praxen report in five minutes · Praxen Docs</title>
+<title>Quickstart — your first Praxen report in about 15 minutes · Praxen Docs</title>
 <style>@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
 /*
   Copyright 2026 Exabeam, Inc.
@@ -241,82 +241,78 @@ img { max-width: 100%; display: block; }
   </div>
 </header>
 <div class="docs-shell">
-  <aside class="docs-sidebar"><nav class="docs-nav"><div class="docs-nav-title">Documentation</div><ul><li><a href="index.html">Overview</a></li><li><a href="installation.html">Installation</a></li><li><a href="quickstart.html" class="active">Quickstart</a><ul class="docs-subnav"><li><a href="#1-get-a-copy-of-the-praxen-repository">1. Get a copy of the Praxen repository</a></li><li><a href="#2-get-the-finbot-source">2. Get the FinBot source</a></li><li><a href="#3-run-the-analysis">3. Run the analysis</a></li><li><a href="#4-open-the-report">4. Open the report</a></li><li><a href="#5-now-try-your-own-agent">5. Now try your own agent</a></li><li><a href="#if-something-went-wrong">If something went wrong</a></li></ul></li><li><a href="usage.html">Usage</a></li><li><a href="writing-remits.html">Writing Worker Remits</a></li><li><a href="interpreting-reports.html">Interpreting Reports</a></li><li><a href="challenging-findings.html">Challenging Findings</a></li><li><a href="understanding-variability.html">Run-to-Run Variability</a></li><li><a href="abv.html">Agent Behavior Verification</a></li><li><a href="owasp.html">OWASP Gen AI Security</a></li><li><a href="RAISE.html">The RAISE Framework</a></li></ul></nav></aside>
+  <aside class="docs-sidebar"><nav class="docs-nav"><div class="docs-nav-title">Documentation</div><ul><li><a href="index.html">Overview</a></li><li><a href="installation.html">Installation</a></li><li><a href="quickstart.html" class="active">Quickstart</a><ul class="docs-subnav"><li><a href="#set-up">Set up</a></li><li><a href="#1-have-claude-author-the-worker-remit">1. Have Claude author the Worker Remit</a></li><li><a href="#2-have-claude-run-the-scan">2. Have Claude run the scan</a></li><li><a href="#3-read-the-report">3. Read the report</a></li><li><a href="#bonus-dont-just-measure-improve">Bonus — don&#x27;t just measure, improve</a></li><li><a href="#now-point-it-at-your-own-agent">Now point it at your own agent</a></li><li><a href="#if-something-went-wrong">If something went wrong</a></li></ul></li><li><a href="usage.html">Usage</a></li><li><a href="writing-remits.html">Writing Worker Remits</a></li><li><a href="interpreting-reports.html">Interpreting Reports</a></li><li><a href="challenging-findings.html">Challenging Findings</a></li><li><a href="understanding-variability.html">Run-to-Run Variability</a></li><li><a href="abv.html">Agent Behavior Verification</a></li><li><a href="owasp.html">OWASP Gen AI Security</a></li><li><a href="RAISE.html">The RAISE Framework</a></li></ul></nav></aside>
   <main class="docs-main">
-    <article class="prose"><h1 id="quickstart-your-first-praxen-report-in-five-minutes">Quickstart — your first Praxen report in five minutes</h1>
-<p>This walks you from "Praxen is installed" to "I have a real report" against <strong>FinBot</strong>, a deliberately vulnerable invoice-processing agent from the OWASP Agentic AI CTF. No editing your own agent required. (FinBot is small, so five minutes is realistic; a real-world target typically takes longer — see <a href="usage.html">Usage</a>.)</p>
-<p>Every Praxen scan needs <strong>two separate inputs</strong>: a <strong>Worker Remit</strong> (the policy) and a <strong>separate agent source tree</strong> (the evidence). Here you'll use the bundled FinBot remit and clone FinBot's source from upstream. The <code>examples/finbot/</code> report files are the <em>reference output</em> — what your run should approximately produce — <strong>not</strong> the thing you scan.</p>
-<p>If you haven't installed yet, do <a href="installation.html">Installation</a> first — one marketplace command on Claude Code, or a one-line skill link on Codex.</p>
-<h2 id="1-get-a-copy-of-the-praxen-repository">1. Get a copy of the Praxen repository</h2>
-<p>If you don't have a local copy of the Praxen repository yet, clone it:</p>
-<pre><code class="language-bash">git clone https://github.com/open-agent-ai-security/praxen.git
-cd praxen
+    <article class="prose"><h1 id="quickstart-your-first-praxen-report-in-about-15-minutes">Quickstart — your first Praxen report in about 15 minutes</h1>
+<p>A complete Praxen run, end to end: you'll have Claude <strong>author a security policy</strong> for a real agent, <strong>verify the agent's code against it</strong>, and read the report — all from plain-English instructions. The target is <strong>FinBot</strong>, a deliberately vulnerable invoice-processing agent from the OWASP Agentic AI CTF, so the divergences are dramatic and easy to learn from.</p>
+<p>You do very little here — four short instructions; Claude does the work: fetching docs, writing the policy, cloning the code, running the analysis, and rendering the report. Budget about 15 minutes, most of it Claude thinking while you watch.</p>
+<blockquote>
+<p>Not installed yet? Do <a href="installation.html">Installation</a> first — one marketplace command on Claude Code, or a one-line skill link on Codex. There's nothing else to clone or download; Claude pulls what it needs.</p>
+</blockquote>
+<h2 id="set-up">Set up</h2>
+<p>Start a Claude Code session in a fresh, empty folder — that's where the remit and the <code>reports/</code> will land:</p>
+<pre><code class="language-bash">mkdir finbot-quickstart &amp;&amp; cd finbot-quickstart
+claude
 </code></pre>
-<p>The only thing you'll take from <code>examples/finbot/</code> is the <strong>remit</strong> — the rest of that folder is the reference report:</p>
-<pre><code>examples/finbot/
-  WORKER_REMIT.md          ← the policy doc you'll verify against  (the one input you use)
-  finbot-analysis.html     ← reference report — what your run should approximately produce (NOT a scan target)
-  finbot-findings.json     ← the same reference findings, as JSON                          (NOT a scan target)
-</code></pre>
-<p>You'll get the <em>other</em> input — the agent source to scan — by cloning FinBot from upstream in the next step. A real first scan would use <em>your</em> agent's source plus a remit you wrote; we're using the pre-staged remit so the first run has no moving parts.</p>
-<h2 id="2-get-the-finbot-source">2. Get the FinBot source</h2>
-<p>The example was developed against the <strong>CineFlow Productions finbot</strong> from the OWASP Agentic AI CTF (see <a href="https://github.com/open-agent-ai-security/praxen/blob/main/examples/README.md"><code>examples/README.md</code></a> for the full provenance). Clone the source so Praxen has a real workspace to read:</p>
-<pre><code class="language-bash">git clone https://github.com/OWASP-ASI/finbot-ctf-demo.git ../finbot-src
-</code></pre>
-<p>(Any directory will do — <code>../finbot-src</code> keeps the clone outside the Praxen tree and works the same on macOS, Linux, and Windows.)</p>
-<h2 id="3-run-the-analysis">3. Run the analysis</h2>
-<p>From a Claude Code session in the <code>praxen</code> repo directory, ask the agent:</p>
-<pre><code>Please run the behavior-verifier skill against ../finbot-src.
-Use the Worker Remit at examples/finbot/WORKER_REMIT.md. Write outputs
-to ./reports/finbot-quickstart/.
-</code></pre>
-<p><strong>On Codex</strong> the flow is identical. After the one-time user-wide skill link (<a href="installation.html#option-b--openai-codex-agent-skill">Installation</a> Option B), run the same request via <code>codex exec</code> from the <code>praxen</code> repo directory:</p>
-<pre><code class="language-bash">codex exec --sandbox workspace-write -C &quot;$(pwd)&quot; \
-  'Use $praxen:behavior-verifier. Run a Praxen behavior analysis against ../finbot-src. Use the Worker Remit at examples/finbot/WORKER_REMIT.md. Write outputs to ./reports/finbot-quickstart/.'
-</code></pre>
-<p>That's the whole prompt. Praxen will:</p>
-<ol>
-<li>Read the Worker Remit</li>
-<li>Sweep the workspace at <code>../finbot-src</code></li>
-<li>Score the six RAISE categories</li>
-<li>Audit every remit rule</li>
-<li>Surface compound attack chains</li>
-<li>Write three files to <code>./reports/finbot-quickstart/</code> (plus a working draft checkpoint it may clean up)</li>
-</ol>
-<p>The skill prints an interim overview to stdout while it works. When it finishes you'll have:</p>
-<pre><code>./reports/finbot-quickstart/
-  finbot-findings-YYYY-MM-DD.json     ← canonical record
-  finbot-analysis-YYYY-MM-DD-HHMMSS.html  ← human-readable report
-  finbot-analysis-YYYY-MM-DD-HHMMSS.txt   ← plain-text summary
-</code></pre>
-<h2 id="4-open-the-report">4. Open the report</h2>
-<pre><code class="language-bash">open ./reports/finbot-quickstart/finbot-analysis-*.html
-</code></pre>
-<p>(<code>open</code> is macOS; on Linux use <code>xdg-open</code>, on Windows the file works in any browser.)</p>
-<p>What you should see, top to bottom:</p>
+<p>As you go, Claude will ask permission to do things like clone the repo, write the remit, and run the renderer — approve them.</p>
+<h2 id="1-have-claude-author-the-worker-remit">1. Have Claude author the Worker Remit</h2>
+<p>A Praxen scan checks an agent against a <strong>Worker Remit</strong> — a plain-language policy of what the agent is <em>supposed</em> to do. Rather than hand-write one, have Claude do it:</p>
+<blockquote>
+<p><em>Author a Worker Remit for this agent from its repo docs. It's an intentionally vulnerable bot, so build the remit from the </em><em>intended</em><em> ("desired") behavior in the docs — don't read the implementation code: https://github.com/OWASP-ASI/finbot-ctf-demo</em></p>
+</blockquote>
+<p><strong>What Claude does:</strong> loads the Praxen skill, reads the repo's README and design/walkthrough docs (not the code), and — because FinBot's docs are an <em>attack</em> walkthrough — inverts each documented exploit into the secure behavior it violates. It writes <code>WORKER_REMIT.md</code> and appends a short <strong>Open Questions</strong> list for what it can't infer (the real approval thresholds, whether vendors are allowlisted, whether MFA is required). A couple of minutes.</p>
+<p><strong>Why "don't read the code" matters:</strong> the remit is the standard the scan judges the code against. If you author it <em>from</em> the implementation, it just mirrors what the code already does — and the scan finds nothing. Building it from stated intent is what gives the scan something real to measure against. (This discipline is built into the skill; see <a href="writing-remits.html">Writing Worker Remits</a>.) Skim <code>WORKER_REMIT.md</code> — it's your policy, and you can tighten it or answer the Open Questions before scanning if you want a sharper result.</p>
+<h2 id="2-have-claude-run-the-scan">2. Have Claude run the scan</h2>
+<p>Now point Praxen at the agent's actual code, using the remit it just wrote:</p>
+<blockquote>
+<p><em>Run the scan now, using the remit you built.</em></p>
+</blockquote>
+<p><strong>What Claude does:</strong> clones FinBot itself, sweeps the workspace, scores the six RAISE categories, audits every remit rule, checkpoints the analysis to a draft manifest (so a long run survives a context-window compaction), and renders the report. Several minutes — this is the long pole of the run.</p>
+<p><strong>What you'll see:</strong> FinBot lands at a RAISE posture of <strong>"Absent"</strong> — a near-floor score, expected for a deliberately-broken agent — with a dozen-plus findings, <strong>Criticals first</strong>. The headline is a compound chain: an unauthenticated admin plane → attacker text written into the agent's goals → no approval gate on payments → no audit log — the exact goal-hijack-to-autonomous-payment path the CTF is built around. It also notes what FinBot gets <em>right</em> (no code-execution capability, a bounded agent loop), so the report isn't only a list of failures.</p>
+<p><em>(Exact counts and the score shift from run to run — synthesis is an act of judgment, not a fixed function. The themes are the stable signal; see <a href="understanding-variability.html">Run-to-Run Variability</a>.)</em></p>
+<h2 id="3-read-the-report">3. Read the report</h2>
+<blockquote>
+<p><em>Show me the report in the browser.</em></p>
+</blockquote>
+<p>Claude opens the self-contained HTML report. Read it top to bottom:</p>
 <ul>
-<li>A red <strong>CRITICAL</strong> status badge — FinBot is deliberately broken</li>
-<li>An <strong>Agent Remit</strong> panel restating what the remit says, alongside an <strong>Agent Structure</strong> panel summarising what Praxen found in the workspace</li>
-<li>A <strong>Behavior Summary</strong> — the dominant pattern (typically something like <em>"framework offers safe primitives, code uses none of them"</em>)</li>
-<li>A <strong>Remit Coverage</strong> table listing every rule with status (<code>Verified</code> / <code>Gap</code> / <code>Partial</code> / <code>Vague</code> / <code>ENP</code>)</li>
-<li>A <strong>Findings Register</strong> — Critical first, then High, Medium, Low, Informational, each with evidence and a recommended action</li>
-<li>A <strong>RAISE Maturity Posture</strong> wrap-up — a 0–5 weighted score across six categories</li>
+<li><strong>Behavior Summary + RAISE scorecard</strong> — the one-line story (something like <em>"safe primitives offered, none used"</em>) and the 0–5 weighted maturity score across six categories, color-graded by score.</li>
+<li><strong>Findings register</strong> — Critical first, then High → Informational. Each card carries its <strong><code>file:line</code> evidence</strong> and the <strong>remit rule(s) it violates</strong>, plus a recommended action.</li>
+<li><strong>Remit Coverage table</strong> — every rule you authored, marked <code>Verified</code> / <code>Gap</code> / <code>Partial</code> / <code>Vague</code> / <code>ENP</code> (exists-not-proven). This is where you see how much of your policy the code actually honors.</li>
+<li><strong>OWASP heatmaps</strong> + <strong>Positives</strong> — the findings mapped to the OWASP LLM and Agentic risk catalogs, and the controls that <em>are</em> present and working.</li>
 </ul>
-<p>You can compare your fresh report against the <a href="https://open-agent-ai-security.github.io/praxen/examples/finbot/finbot-analysis.html">published FinBot example report</a> (rendered on GitHub Pages). It won't be byte-identical (LLM analyses have run-to-run variance) but the dominant Critical themes, the broad RAISE shape, and the remit-coverage counts should be close. See <a href="https://github.com/open-agent-ai-security/praxen/blob/main/tests/README.md">tests/README.md</a> for what "close" actually means for this target.</p>
-<h2 id="5-now-try-your-own-agent">5. Now try your own agent</h2>
-<p>The pattern is identical with a real target:</p>
+<p>Ask Claude to walk through any finding — <em>"explain PRAX-005"</em>, <em>"why is this Critical?"</em> — and it re-examines the evidence with you. The analysis is conversational, so you can challenge or revise it; see <a href="challenging-findings.html">Challenging and Revising Findings</a>.</p>
+<h2 id="bonus-dont-just-measure-improve">Bonus — don't just measure, improve</h2>
+<p>At this point Praxen has done its core job: you have a report that tells you exactly where FinBot diverges from its remit. But a verifier that only measures is half a tool. A Praxen finding isn't just a label — it carries <code>file:line</code> evidence and a recommended action — so it's something you can act on. Close the loop.</p>
+<p>Ask Claude to fix the worst one:</p>
+<blockquote>
+<p><em>Find the most critical finding and create a fix.</em></p>
+</blockquote>
+<p><strong>What Claude does:</strong> it identifies the highest-priority finding, targets a fix in the agent's code, verifies the change, and reports back what it changed and what's still open. Which finding it leads with and how it fixes it will vary — that's a judgment call on a live codebase — but the shape is consistent: one concrete, load-bearing fix, verified, not a vague to-do list.</p>
+<p><em>In one run, for example,</em> it targeted FinBot's missing payment-approval gate, added a deterministic check that routes high-value or manipulation-flagged invoices to human review before any payment, then verified it end-to-end — running a manipulated "CEO-approved, $25k, urgent" invoice through the real decision path and confirming it now stops at review while clean invoices still pass.</p>
+<p>Now re-verify — run the same loop again:</p>
+<blockquote>
+<p><em>Re-run the Praxen scan and show me what changed.</em></p>
+</blockquote>
+<p>The finding you fixed should resolve or downgrade, its remit rule should move toward <code>Verified</code>, and the RAISE posture should tick up. It won't jump to green — FinBot has plenty more deliberate holes, and the report now points you at the next one. That's the model: <strong>measure → remediate → re-verify</strong>, one link at a time, with the report as your worklist.</p>
+<p>That loop — verify intent, fix the divergence, prove the fix landed — is the whole idea. Praxen doesn't just tell you an agent is unsafe; it hands you an actionable, re-checkable path to making it safe.</p>
+<h2 id="now-point-it-at-your-own-agent">Now point it at your own agent</h2>
+<p>Same moves, your target:</p>
 <ol>
-<li><a href="writing-remits.html">Write a Worker Remit</a> for the agent</li>
-<li>Point Praxen at whatever evidence you have — source, deployment files, behavioral logs, governance docs</li>
-<li>Read the report; <a href="challenging-findings.html">iterate</a> on the remit and the agent as needed</li>
+<li>Ask Claude to <strong>author a remit</strong> from your agent's docs and intended behavior (or <a href="writing-remits.html">write one yourself</a>)</li>
+<li>Ask it to <strong>scan</strong> your agent's evidence against it — source, deployment files, behavioral logs, governance docs</li>
+<li><strong>Read</strong> the report, then <a href="challenging-findings.html">iterate</a> on the remit and the agent</li>
 </ol>
 <p>See <a href="usage.html">Usage</a> for the full set of input shapes and the running-an-analysis details.</p>
+<blockquote>
+<p><strong>Want a fixed, repeatable result</strong> — a regression baseline rather than a tutorial? Use a pinned remit instead of authoring one each time. The bundled <code>examples/finbot/WORKER_REMIT.md</code> and its <a href="https://open-agent-ai-security.github.io/praxen/examples/finbot/finbot-analysis.html">reference report</a> are exactly that; see <a href="https://github.com/open-agent-ai-security/praxen/blob/main/tests/README.md">tests/README.md</a>.</p>
+</blockquote>
 <h2 id="if-something-went-wrong">If something went wrong</h2>
 <p>See the <a href="usage.html#troubleshooting">Troubleshooting</a> section in <code>usage.md</code>. The most common first-run snags:</p>
 <ul>
 <li><strong>"behavior-verifier skill not found"</strong> — restart Claude Code or run <code>/reload-plugins</code></li>
-<li><strong><code>render.py</code> errored at the end</strong> — the LLM produced a malformed findings JSON; re-run with more context window or a more focused workspace path</li>
-<li><strong>Context window auto-compacted during the run</strong> — Praxen wrote a draft manifest in <code>./reports/&lt;agent-slug&gt;-draft-&lt;timestamp&gt;.md</code>; tell the agent to read it and finish from there. See <a href="usage.html#large-workspaces-and-context-sizing">Usage § Large workspaces and context sizing</a>.</li>
+<li><strong><code>render.py</code> errored at the end</strong> — the model produced malformed findings JSON; ask Claude to re-render from the draft manifest it wrote, or re-run with a tighter workspace path</li>
+<li><strong>Context window auto-compacted during the run</strong> — Praxen wrote a draft manifest at <code>./reports/&lt;agent-slug&gt;-draft-&lt;timestamp&gt;.md</code>; tell Claude to read it and finish the report from there. See <a href="usage.html#large-workspaces-and-context-sizing">Usage § Large workspaces and context sizing</a>.</li>
 </ul></article>
     <p class="docs-edit"><a href="https://github.com/open-agent-ai-security/praxen/blob/main/docs/quickstart.md" target="_blank" rel="noopener">Edit this page on GitHub ↗</a></p>
   </main>

--- a/guide/quickstart.html
+++ b/guide/quickstart.html
@@ -250,6 +250,7 @@ img { max-width: 100%; display: block; }
 <p>Not installed yet? Do <a href="installation.html">Installation</a> first — one marketplace command on Claude Code, or a one-line skill link on Codex. There's nothing else to clone or download; Claude pulls what it needs.</p>
 </blockquote>
 <h2 id="set-up">Set up</h2>
+<p>This walkthrough uses <strong>Claude Code</strong>; <strong>OpenAI Codex</strong> works the same way. Wherever it says <code>claude</code> or "ask Claude," substitute your Codex invocation — <code>$praxen:behavior-verifier</code> run via <code>codex exec</code> (see <a href="installation.html#option-b--openai-codex-agent-skill">Installation</a>) — and the four plain-English requests below work unchanged.</p>
 <p>Start a Claude Code session in a fresh, empty folder — that's where the remit and the <code>reports/</code> will land:</p>
 <pre><code class="language-bash">mkdir finbot-quickstart &amp;&amp; cd finbot-quickstart
 claude

--- a/guide/quickstart.html
+++ b/guide/quickstart.html
@@ -245,12 +245,12 @@ img { max-width: 100%; display: block; }
   <main class="docs-main">
     <article class="prose"><h1 id="quickstart-your-first-praxen-report-in-about-15-minutes">Quickstart — your first Praxen report in about 15 minutes</h1>
 <p>A complete Praxen run, end to end: you'll have Claude <strong>author a security policy</strong> for a real agent, <strong>verify the agent's code against it</strong>, and read the report — all from plain-English instructions. The target is <strong>FinBot</strong>, a deliberately vulnerable invoice-processing agent from the OWASP Agentic AI CTF, so the divergences are dramatic and easy to learn from.</p>
+<p>This walkthrough uses <strong>Claude Code</strong>; <strong>OpenAI Codex</strong> works the same way — wherever it says <code>claude</code> or "ask Claude," substitute your Codex invocation, and the steps are identical.</p>
 <p>You do very little here — four short instructions; Claude does the work: fetching docs, writing the policy, cloning the code, running the analysis, and rendering the report. Budget about 15 minutes, most of it Claude thinking while you watch.</p>
 <blockquote>
 <p>Not installed yet? Do <a href="installation.html">Installation</a> first — one marketplace command on Claude Code, or a one-line skill link on Codex. There's nothing else to clone or download; Claude pulls what it needs.</p>
 </blockquote>
 <h2 id="set-up">Set up</h2>
-<p>This walkthrough uses <strong>Claude Code</strong>; <strong>OpenAI Codex</strong> works the same way. Wherever it says <code>claude</code> or "ask Claude," substitute your Codex invocation, and the four plain-English requests below work unchanged.</p>
 <p>Start a Claude Code session in a fresh, empty folder — that's where the remit and the <code>reports/</code> will land:</p>
 <pre><code class="language-bash">mkdir finbot-quickstart &amp;&amp; cd finbot-quickstart
 claude


### PR DESCRIPTION
Rewrites the Quickstart into a real **tutorial** that matches how Praxen is actually used — author a remit, scan, read, improve — instead of a fixed-remit "test."

### Why
The old quickstart contradicted the landing page (it sells "just a plugin, one command," then Step 1 made you `git clone` the whole repo), hid remit-authoring behind a pre-baked remit (felt like cheating), and framed success as matching a baseline (test-mindset, not a tutorial).

### What changed
- **No user-side `git clone`/`curl`.** Four plain-English instructions; Claude fetches docs, writes the remit, clones the code, scans, and renders.
- **Leads with remit authoring** — a first-class capability — with the anti-mirror discipline spelled out (author from *intended* behavior, not the implementation).
- **New "don't just measure, improve" bonus** — have Claude fix the top finding and re-scan: verify → remediate → re-verify. Behavior described generically with an *"in one run, for example"* illustration (no over-specific promises).
- **Tutorial framing** — the bundled remit + reference report are demoted to an optional "want a repeatable result" note, not a target to match.
- **5 → 15 minutes** (realistic once remit authoring + scan + reading are included); the four cross-refs in `index.md`/`abv.md`/`installation.md`/`README.md` updated to match the new flow + time.
- Regenerated `guide/{quickstart,index,abv,installation}.html`.

Docs-only. Verified the rendered `guide/quickstart.html` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)