### PR TITLE
docs: OpenAI Codex plugin-marketplace install + install/usage cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ That's where the risk actually lives: most agentic security and safety failures 
 
 **📦 Install** — Praxen runs on **Claude Code** and **OpenAI Codex** (same skill, platform-specific packaging):
 - **Claude Code:** one command — `claude plugin marketplace add open-agent-ai-security/praxen && claude plugin install praxen@open-agent-ai-security`
-- **OpenAI Codex:** one command — `codex plugin marketplace add open-agent-ai-security/praxen && codex plugin add praxen@open-agent-ai-security` (or link `skills/behavior-verifier` into `.agents/skills/`)
+- **OpenAI Codex:** one command — `codex plugin marketplace add open-agent-ai-security/praxen && codex plugin add praxen@open-agent-ai-security`
 
-Full guide (including the unzipped-release path, which works for either): [docs/installation.md](docs/installation.md).
+Full guide (including the no-marketplace path — just point any other agent at the repo): [docs/installation.md](docs/installation.md).
 
 **👀 See a real report** first — the [live FinBot analysis report](https://open-agent-ai-security.github.io/praxen/examples/finbot/finbot-analysis.html), rendered on GitHub Pages.
 
@@ -82,7 +82,7 @@ Each finding is tagged against the **OWASP Top 10 for LLM Applications 2025**, *
 
 ## Get started
 
-- [**Installation**](docs/installation.md) — Claude Code or OpenAI Codex (plugin / skill folder, or unzipped release)
+- [**Installation**](docs/installation.md) — Claude Code or OpenAI Codex (plugin marketplace), or any other agent (point it at the repo)
 - [**Quickstart**](docs/quickstart.md) — your first end-to-end report in about 15 minutes: have Claude author a remit for the FinBot demo agent, scan it, and read the report
 - [**Writing Worker Remits**](docs/writing-remits.md) — authoring the policy document
 - [**Usage**](docs/usage.md) — running an analysis end-to-end

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ That's where the risk actually lives: most agentic security and safety failures 
 
 **📦 Install** — Praxen runs on **Claude Code** and **OpenAI Codex** (same skill, platform-specific packaging):
 - **Claude Code:** one command — `claude plugin marketplace add open-agent-ai-security/praxen && claude plugin install praxen@open-agent-ai-security`
-- **OpenAI Codex:** link `skills/behavior-verifier` into `.agents/skills/` and invoke `$praxen:behavior-verifier`
+- **OpenAI Codex:** one command — `codex plugin marketplace add open-agent-ai-security/praxen && codex plugin add praxen@open-agent-ai-security` (or link `skills/behavior-verifier` into `.agents/skills/`)
 
 Full guide (including the unzipped-release path, which works for either): [docs/installation.md](docs/installation.md).
 

--- a/docs/challenging-findings.md
+++ b/docs/challenging-findings.md
@@ -25,7 +25,7 @@ Each of these has a different remediation path.
 
 If the finding is correct given the evidence Praxen saw but wrong because Praxen didn't see something it should have:
 
-- **Add the missing evidence to the next analysis.** Point Praxen at the additional directory, log file, or transcript that contains the missing control. Re-run.
+- **Add the missing evidence to the next analysis.** Point Praxen at the additional directory, log file, or transcript that contains the missing control. Re-run. (See [Results tuning](usage.md#results-tuning) for the operational loop, including image/screenshot evidence.)
 - **Don't loosen the remit just to silence the finding.** A finding that disappears because the remit was weakened is now a real gap that won't be caught next time.
 - **Document the dependency.** If the missing control lives outside the agent's repository (a sidecar, an upstream gateway, a platform-enforced policy), record this in the remit's *Trusted Services / Integrations* section and explicitly note that the control is enforced externally. Praxen can then mark the rule as `Enforcement Not Possible` (in code) rather than as a Gap.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,25 +10,25 @@ Praxen ships as a portable **agent skill**, packaged for both **Claude Code** an
 ## Prerequisites
 
 - **A coding agent** capable of tool use and multi-step instruction-following. Praxen is tested against [Claude Code](https://docs.claude.com/en/docs/claude-code/overview) and [OpenAI Codex](https://developers.openai.com/codex/skills); other coding agents that can read a skill markdown file and call tools (Read, Grep, Glob, Bash, Write) should also work.
-- **Python 3.9 or newer on the PATH.** Praxen's report renderer (`render.py`, bundled with the skill) is plain Python 3 — standard library only, nothing to `pip install`. 3.9 is the macOS Command Line Tools system Python (Ventura / Sonoma / Sequoia), so on macOS there's typically nothing to install. On Windows, `py -3` works. If `python3` isn't found, the renderer step falls back to `python`.
+- **Python 3.9 or newer on the PATH** — for the bundled report renderer (`render.py`), which is standard-library only (nothing to `pip install`). You almost certainly already have it: 3.9 ships as the macOS Command Line Tools system Python, and on Windows `py -3` works. (If `python3` isn't found, the renderer falls back to `python`.)
 - **Network access for your coding agent's LLM provider** during analysis. Praxen itself does not phone home, but the LLM calls your coding agent makes during analysis follow whatever provider configuration the agent uses.
-- **Workspace write permission for the agent.** Praxen writes its report files to a `./reports/` directory and runs two bundled Python scripts during a scan, so the agent must be allowed to write within the working directory (the default in Claude Code; on Codex, run with a workspace-write sandbox — see below).
+- **Workspace write permission for the agent.** Praxen writes its report files to a `./reports/` directory and runs two bundled Python scripts during a scan, so the agent must be allowed to write within the working directory. Claude Code allows this by default; agents that sandbox file writes need that permission granted (per your agent's own docs).
 
 That's the entire dependency surface.
 
-## Option A — Claude Code (plugin marketplace)
+## Claude Code
 
-The recommended path for Claude Code users. From your terminal:
+Install from the plugin marketplace. From your terminal:
 
 ```bash
 claude plugin marketplace add open-agent-ai-security/praxen
 claude plugin install praxen@open-agent-ai-security
-claude plugin list      # confirm: praxen@open-agent-ai-security, enabled, v0.8.0+
+claude plugin list      # confirm: praxen@open-agent-ai-security, enabled, v1.0.0+
 ```
 
 The skill registers as `behavior-verifier`. The in-session equivalents — `/plugin marketplace add …`, `/plugin install …`, `/plugin list` — do exactly the same thing; if you install from within a Claude Code session, run `/reload-plugins` (or restart) to activate the skill. Prefer the terminal form when scripting: `claude plugin …` is argument-driven and runs the same way on every interface, whereas in-session slash commands occasionally fall through and get sent as ordinary chat messages.
 
-## Option B — OpenAI Codex (plugin marketplace)
+## OpenAI Codex
 
 Codex has its own plugin marketplace, and Praxen installs from the **same repo** as the Claude Code path. From your terminal:
 
@@ -38,53 +38,15 @@ codex plugin add praxen@open-agent-ai-security
 codex plugin list      # confirm: praxen@open-agent-ai-security, installed, enabled, v1.0.0+
 ```
 
-Codex surfaces the bundled skill to the model as **`praxen:behavior-verifier`** — the plugin-qualified `plugin:skill` id, the same shape Codex uses for its own first-party skills (`pdf`, `presentations`, …). Invoke it by naming that skill and pointing Codex at a target. Praxen needs workspace writes (it creates `./reports/` and runs two bundled Python scripts), so run `codex exec` with a workspace-write sandbox:
+This installs and enables the plugin in Codex's local config; the bundled `behavior-verifier` skill is then available to every Codex session. Running an analysis is the same as on any agent — see [Usage](usage.md).
 
-```bash
-codex exec --sandbox workspace-write -C /path/to/scan-dir \
-  'Use the praxen:behavior-verifier skill. Run a Praxen behavior analysis against ./target. Use the Worker Remit at ./WORKER_REMIT.md. Write outputs to ./reports/.'
-```
+## Any other agent
 
-That's the whole happy path; for an end-to-end first run, see [Quickstart](quickstart.md).
+No marketplace, no download step — Praxen is just a skill folder in a public repo, so any capable coding agent can fetch and run it from a plain-English instruction. (This also works on Claude Code or Codex if you'd rather skip the marketplace.) In your agent session, say something like:
 
-### Alternative — link the skill folder directly
+> Clone `https://github.com/open-agent-ai-security/praxen` and follow its `behavior-verifier` skill to run a Praxen behavior analysis on [your target]. Use the Worker Remit at [path].
 
-No marketplace required: Codex also discovers skills from an `.agents/skills/` directory. A **user-wide skill link** makes Praxen available from every Codex session, from any directory:
-
-```bash
-cd /path/to/praxen          # your checkout or unzipped release (Option C)
-mkdir -p "$HOME/.agents/skills"
-ln -sfn "$PWD/skills/behavior-verifier" "$HOME/.agents/skills/behavior-verifier"
-```
-
-To scope the skill to a single project instead, link it into that repo's own `.agents/skills/`.
-
-## Option C — Run from an unzipped release (either agent)
-
-If you can't or don't want to use a marketplace flow, unzip the release archive somewhere your coding agent can see it. There's no install step — the archive carries both the `.claude-plugin/` and `.codex-plugin/` manifests plus the shared `skills/` engine.
-
-```bash
-# Replace VERSION with the release tag and RELEASE_URL with the .zip asset URL
-curl -L -o praxen-VERSION.zip RELEASE_URL
-unzip praxen-VERSION.zip
-cd praxen-VERSION
-```
-
-Then point your coding agent at `skills/behavior-verifier/SKILL.md` (Claude Code), or link it into `.agents/skills/` and invoke `$praxen:behavior-verifier` (Codex, per Option B). See [Usage](usage.md).
-
-## Verifying the install
-
-**Claude Code:**
-
-```bash
-claude plugin list
-```
-
-If `praxen@open-agent-ai-security` appears at `v0.8.0` or later with `enabled`, the marketplace install is working. From within a session the same plugin shows under `/plugin list`, and the skill is invocable as `behavior-verifier`.
-
-**Codex (marketplace):** run `codex plugin list` — if `praxen@open-agent-ai-security` shows `installed, enabled` at `v1.0.0` or later, the install is working. Inside a session the skill appears to the model as `praxen:behavior-verifier` (or browse with `/skills`). That's the parity check, the same way `claude plugin list` is for Claude Code.
-
-For the first **end-to-end run** — declared intent → evidence → HTML / JSON / TXT report — see [Quickstart](quickstart.md). It walks through having Claude author a Worker Remit for the FinBot demo agent, scan the code against it, and read the report, in about 15 minutes — all from plain-English instructions.
+The agent brings down its own copy and runs the skill from `skills/behavior-verifier/`. Offline? Download the release `.zip` from the [releases page](https://github.com/open-agent-ai-security/praxen/releases) and point your agent at the unzipped folder instead. See [Usage](usage.md) for the analysis instructions.
 
 ## Updating
 
@@ -136,11 +98,9 @@ codex plugin marketplace upgrade open-agent-ai-security   # refresh the snapshot
 codex plugin add praxen@open-agent-ai-security             # install the refreshed version
 ```
 
-(If `codex plugin add` reports the plugin is already installed, run `codex plugin remove praxen@open-agent-ai-security` first, then add again.)
+### Any other agent
 
-### OpenAI Codex (skill link) / unzipped release
-
-If you linked the skill folder or run from an unzipped release, updating is manual: `git pull` the checkout (a symlinked skill folder picks up the new version automatically), or download the new release zip and replace it. There's no migration step; Praxen is stateless across analyses.
+Tell the agent to `git pull` its clone (or re-clone), or download a newer release `.zip`. There's no migration step — Praxen is stateless across analyses.
 
 ## Uninstalling
 
@@ -160,9 +120,7 @@ codex plugin remove praxen@open-agent-ai-security
 codex plugin marketplace remove open-agent-ai-security
 ```
 
-**OpenAI Codex (skill link):** remove the link — `rm .agents/skills/behavior-verifier` (or `rm ~/.agents/skills/behavior-verifier`).
-
-**Unzipped release:** delete the directory. No system state is left behind.
+**Any other agent:** delete the cloned (or unzipped) folder. No system state is left behind.
 
 ## Next steps
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -28,9 +28,28 @@ claude plugin list      # confirm: praxen@open-agent-ai-security, enabled, v0.8.
 
 The skill registers as `behavior-verifier`. The in-session equivalents — `/plugin marketplace add …`, `/plugin install …`, `/plugin list` — do exactly the same thing; if you install from within a Claude Code session, run `/reload-plugins` (or restart) to activate the skill. Prefer the terminal form when scripting: `claude plugin …` is argument-driven and runs the same way on every interface, whereas in-session slash commands occasionally fall through and get sent as ordinary chat messages.
 
-## Option B — OpenAI Codex (agent skill)
+## Option B — OpenAI Codex (plugin marketplace)
 
-Codex discovers skills from a `.agents/skills/` directory. The first-class path is a **user-wide skill link** — set it up once and every Codex session can invoke Praxen, from any directory:
+Codex has its own plugin marketplace, and Praxen installs from the **same repo** as the Claude Code path. From your terminal:
+
+```bash
+codex plugin marketplace add open-agent-ai-security/praxen
+codex plugin add praxen@open-agent-ai-security
+codex plugin list      # confirm: praxen@open-agent-ai-security, installed, enabled, v1.0.0+
+```
+
+Codex surfaces the bundled skill to the model as **`praxen:behavior-verifier`** — the plugin-qualified `plugin:skill` id, the same shape Codex uses for its own first-party skills (`pdf`, `presentations`, …). Invoke it by naming that skill and pointing Codex at a target. Praxen needs workspace writes (it creates `./reports/` and runs two bundled Python scripts), so run `codex exec` with a workspace-write sandbox:
+
+```bash
+codex exec --sandbox workspace-write -C /path/to/scan-dir \
+  'Use the praxen:behavior-verifier skill. Run a Praxen behavior analysis against ./target. Use the Worker Remit at ./WORKER_REMIT.md. Write outputs to ./reports/.'
+```
+
+That's the whole happy path; for an end-to-end first run, see [Quickstart](quickstart.md).
+
+### Alternative — link the skill folder directly
+
+No marketplace required: Codex also discovers skills from an `.agents/skills/` directory. A **user-wide skill link** makes Praxen available from every Codex session, from any directory:
 
 ```bash
 cd /path/to/praxen          # your checkout or unzipped release (Option C)
@@ -38,16 +57,7 @@ mkdir -p "$HOME/.agents/skills"
 ln -sfn "$PWD/skills/behavior-verifier" "$HOME/.agents/skills/behavior-verifier"
 ```
 
-Codex surfaces the skill as **`praxen:behavior-verifier`** — invoke it by that plugin-qualified name (`$praxen:behavior-verifier`, not `$behavior-verifier`) and point it at a target. Praxen needs workspace writes (it creates `./reports/` and runs two bundled Python scripts), so run `codex exec` with a workspace-write sandbox:
-
-```bash
-codex exec --sandbox workspace-write -C /path/to/scan-dir \
-  'Use $praxen:behavior-verifier. Run a Praxen behavior analysis against ./target. Use the Worker Remit at ./WORKER_REMIT.md. Write outputs to ./reports/.'
-```
-
-That's the whole happy path; for an end-to-end first run, see [Quickstart](quickstart.md). (To scope the skill to a single project instead of user-wide, link it into that repo's own `.agents/skills/`. A public Codex *marketplace* install mirroring Option A is [tracked as a future enhancement](https://github.com/open-agent-ai-security/praxen/issues/102), not yet available.)
-
-> **Two Codex gotchas.** `codex exec -C <dir>` refuses to run outside a trusted git repo (`Not inside a trusted directory…`) — run from a git checkout, or add `--skip-git-repo-check`. And on load Codex may print warnings about *other* installed plugins or a telemetry metric-tag on the `praxen:behavior-verifier` id; those are Codex-side and don't affect the scan.
+To scope the skill to a single project instead, link it into that repo's own `.agents/skills/`.
 
 ## Option C — Run from an unzipped release (either agent)
 
@@ -72,7 +82,7 @@ claude plugin list
 
 If `praxen@open-agent-ai-security` appears at `v0.8.0` or later with `enabled`, the marketplace install is working. From within a session the same plugin shows under `/plugin list`, and the skill is invocable as `behavior-verifier`.
 
-**Codex:** confirm the skill appears to the model as `praxen:behavior-verifier` in Codex's skill list. That's the parity check — it confirms discovery, the same way `claude plugin list` does for Claude Code.
+**Codex (marketplace):** run `codex plugin list` — if `praxen@open-agent-ai-security` shows `installed, enabled` at `v1.0.0` or later, the install is working. Inside a session the skill appears to the model as `praxen:behavior-verifier` (or browse with `/skills`). That's the parity check, the same way `claude plugin list` is for Claude Code.
 
 For the first **end-to-end run** — declared intent → evidence → HTML / JSON / TXT report — see [Quickstart](quickstart.md). It walks through having Claude author a Worker Remit for the FinBot demo agent, scan the code against it, and read the report, in about 15 minutes — all from plain-English instructions.
 
@@ -117,9 +127,20 @@ Auto-update is a **per-marketplace** setting, and for third-party marketplaces l
 
 > Because Praxen is a security tool, staying current matters — enabling auto-update (or updating on a regular cadence) is recommended.
 
-### OpenAI Codex / unzipped release
+### OpenAI Codex — marketplace
 
-There's no marketplace, so updating is manual: `git pull` the checkout (a symlinked skill folder picks up the new version automatically), or download the new release zip and replace it. There's no migration step; Praxen is stateless across analyses.
+Refresh the catalog snapshot, then re-install — the same two-step shape as Claude Code:
+
+```bash
+codex plugin marketplace upgrade open-agent-ai-security   # refresh the snapshot from the repo
+codex plugin add praxen@open-agent-ai-security             # install the refreshed version
+```
+
+(If `codex plugin add` reports the plugin is already installed, run `codex plugin remove praxen@open-agent-ai-security` first, then add again.)
+
+### OpenAI Codex (skill link) / unzipped release
+
+If you linked the skill folder or run from an unzipped release, updating is manual: `git pull` the checkout (a symlinked skill folder picks up the new version automatically), or download the new release zip and replace it. There's no migration step; Praxen is stateless across analyses.
 
 ## Uninstalling
 
@@ -132,7 +153,14 @@ claude plugin marketplace remove open-agent-ai-security
 
 The marketplace is removed by its registered name (`open-agent-ai-security`, from `.claude-plugin/marketplace.json`) — which here matches the repo owner used to add it.
 
-**OpenAI Codex:** remove the skill link — `rm .agents/skills/behavior-verifier` (or `rm ~/.agents/skills/behavior-verifier`).
+**OpenAI Codex (marketplace):**
+
+```bash
+codex plugin remove praxen@open-agent-ai-security
+codex plugin marketplace remove open-agent-ai-security
+```
+
+**OpenAI Codex (skill link):** remove the link — `rm .agents/skills/behavior-verifier` (or `rm ~/.agents/skills/behavior-verifier`).
 
 **Unzipped release:** delete the directory. No system state is left behind.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,7 +11,7 @@ This walkthrough uses **Claude Code**; **OpenAI Codex** works the same way — w
 
 You do very little here — four short instructions; Claude does the work: fetching docs, writing the policy, cloning the code, running the analysis, and rendering the report. Budget about 15 minutes, most of it Claude thinking while you watch.
 
-> Not installed yet? Do [Installation](installation.md) first — one marketplace command on Claude Code, or a one-line skill link on Codex. There's nothing else to clone or download; Claude pulls what it needs.
+> Not installed yet? Do [Installation](installation.md) first — one marketplace command on Claude Code or Codex. There's nothing else to clone or download; Claude pulls what it needs.
 
 ## Set up
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,7 +7,7 @@
 
 Running a Praxen analysis takes two inputs: a **Worker Remit** (the agent's declared policy) and **evidence** (whatever the agent's code, deployment state, behavioral records, or development/governance docs can provide). Praxen produces three output files in `./reports/`.
 
-**Praxen is designed as a read-only external observer.** It reads the artifacts you point it at and writes a local report; it does not modify the agent, sit in its control path, or call any service Praxen itself controls. This read-only posture is a discipline of the skill's instructions rather than a technical sandbox — the analysis runs with the coding agent's ordinary Bash/Write access — but it keeps Praxen suitable as an independent verifier, not self-attestation by the agent under analysis.
+**Praxen is designed as a read-only external observer.** It reads the artifacts you point it at and writes a local report; it does not modify the agent, sit in its control path, or call any service Praxen itself controls. This read-only posture is a discipline of the skill's instructions, not a technical sandbox: the analysis runs with the coding agent's ordinary Bash/Write access. That discipline is what keeps Praxen an independent verifier, rather than self-attestation by the agent under analysis.
 
 This page covers the end-to-end run. For installing Praxen, see [Installation](installation.md). For authoring the Worker Remit, see [Writing Worker Remits](writing-remits.md). For the verification model Praxen implements, see [Agent Behavior Verification](abv.md).
 
@@ -34,7 +34,7 @@ You can provide more than one shape in the same analysis — for example, source
 
 ## Running an analysis
 
-From a Claude Code session (or any coding agent capable of running the skill):
+From inside your coding-agent session — Claude Code, Codex, or any agent that can run the skill — it's the same plain-English instruction:
 
 ```
 Please run the behavior-verifier skill to analyze [path to evidence]. Use the Worker Remit at [path to remit].
@@ -78,9 +78,9 @@ Coverage and confidence increase with each additional input shape — see the [E
 
 ### For highest scan fidelity: run in a fresh context
 
-A scan run in the same session that explored the workspace earlier (while authoring the remit, reading code, or doing prep work) will systematically **under-read** during the Step 4 artifact sweep — the scanner pattern-matches against what it already knows rather than doing a full cold discovery. On a large codebase the gap is real: a cold-context scan reads materially more of the workspace, and that extra evidence can move RAISE scores upward — so a warm-context scan tends to *under*-report.
+A scan run in the same session that explored the workspace earlier (while authoring the remit, reading code, or doing prep work) will systematically **under-read** during the artifact sweep — the scanner pattern-matches against what it already knows rather than doing a full cold discovery. On a large codebase the gap is real: a cold-context scan reads materially more of the workspace, and that extra evidence can move RAISE scores upward — so a warm-context scan tends to *under*-report.
 
-**The recommended approach for a high-confidence scan:** spawn a subagent with no prior context and point it at the workspace. In Claude Code, the Agent tool sends a fresh instance with no conversation history:
+**The recommended approach for a high-confidence scan:** run it in a subagent or a fresh session that carries no prior context, and point it at the workspace:
 
 ```
 Please spawn a subagent with no prior context to run the behavior-verifier skill
@@ -88,7 +88,7 @@ against ./my-agent-repo/. Worker Remit is at ./WORKER_REMIT.md. Output to
 ./reports/.
 ```
 
-This is also the right pattern when the scan follows a remit-authoring session — if Praxen drafted the remit and then immediately scans, the same context holds everything it just read, and Step 4 will be shallow. Finish the remit, confirm it, then start a fresh scan session.
+This is also the right pattern when the scan follows a remit-authoring session — if Praxen drafted the remit and then immediately scans, the same context holds everything it just read, and the artifact sweep will be shallow. Finish the remit, confirm it, then start a fresh scan session.
 
 Praxen reads the evidence, evaluates it against the RAISE Framework and the Worker Remit, and writes three files to `./reports/`:
 
@@ -120,9 +120,9 @@ A new pair of timestamped files is written. Prior reports are not overwritten �
 
 ## Results tuning
 
-Praxen only scores what it can see. If you disagree with a finding — especially a RAISE category score that feels lower than reality — the usual cause is that the evidence you handed it didn't *show* a control that's actually in place: a review process, a deployment-time limit, an external guardrail, a monitoring pipeline, a red-team cadence. Praxen won't assume those exist; it scores absence of evidence as absence of control (see the calibration anchors — present-but-undocumented and present-but-defeated both land low).
+Praxen only scores what it can see. If a finding — or a RAISE category score — feels lower than reality, the usual cause is simple: the evidence you handed it didn't *show* a control that's actually in place (a review process, a deployment-time limit, an external guardrail, a monitoring pipeline, a red-team cadence).
 
-The fix is to give it more evidence and re-run. Add whatever artifact demonstrates the control — a runbook, a CI config, a policy doc, a red-team report, a ticket history, an exported dashboard config, even a written description of the process — and ask Praxen to factor it in:
+The fix is to show it — add whatever artifact demonstrates the control (a runbook, a CI config, a policy doc, a red-team report, a ticket history, an exported dashboard config, even a written description of the process) and ask Praxen to factor it in:
 
 ```
 Here's our red-team report and the production alerting config. Please re-run the
@@ -143,16 +143,16 @@ Praxen does not include a scheduler. If you want recurring analyses, wrap the co
 - **Cron / launchd** — run nightly against a deployed agent's exported state.
 - **GitHub Action** — run on a schedule and post the `.txt` summary as a comment.
 
-Because Praxen is stateless and produces deterministic outputs (modulo timestamp), CI integration is straightforward. The JSON output is the right format for automated downstream consumers.
+Because Praxen is stateless and emits machine-readable JSON, CI integration is straightforward. The JSON output is the right format for automated downstream consumers.
 
 ## Large workspaces and context sizing
 
-A Praxen analysis is read-heavy: it loads the skill procedure, the knowledge bases, and every artifact in the workspace, holds the findings in working memory, and writes the report in a single synthesis pass. On a large target this can exceed the coding agent's context window, and the session **auto-compacts mid-analysis**. That failure is silent — you still get a report, but findings gathered early in the run can be lost or over-summarized by the compaction before the report is written. The goal is to keep the whole scan inside one context window.
+A Praxen analysis is read-heavy: it loads the skill procedure, the knowledge bases, and every artifact in the workspace, holds the findings in working memory, and writes the report in a single synthesis pass. On a large target this can exceed the coding agent's context window, and the session **auto-compacts mid-analysis** — which can thin or over-summarize findings gathered early in the run before the report is written. It's recoverable, not catastrophic: Praxen checkpoints the full analysis to disk just before rendering (the draft manifest, below), and a compacted run leaves visible signs — a compaction notice during the run, and a final report that reads thinner than the interim summary Praxen prints to stdout. Still, the cleanest result comes from keeping the whole scan inside one context window.
 
 **To keep a scan inside the window:**
 
 1. **Use the largest context window available.** This is the biggest lever. In Claude Code, run the analysis in the largest-context session you have access to — a 1M-context (Opus) session if you have one. A 200k-class window can compact partway through a non-trivial agent scan once the procedure, knowledge bases, file reads, and synthesis are all resident at once.
-2. **Start a fresh session for the scan.** Don't run Praxen at the tail of a long conversation that has already consumed most of the window — give the analysis the full budget. A fresh session also gives you a better scan: prior workspace familiarity causes Step 4 to under-read (see *For highest scan fidelity* above).
+2. **Start a fresh session for the scan.** Don't run Praxen at the tail of a long conversation that has already consumed most of the window — give the analysis the full budget. A fresh session also gives you a better scan: prior workspace familiarity causes the artifact sweep to under-read (see *For highest scan fidelity* above).
 3. **Scope the input to the agent, not the whole repo.** Point Praxen at the agent's core surface — its prompts, skill files, code, config, and the Worker Remit — and leave out what isn't the agent: `node_modules` and vendored dependencies, `.git`, `dist` / `build` output, large data and log files, test fixtures. The Worker Remit defines what's in scope; the input path should match. (Praxen already samples large logs and lockfiles rather than reading them whole — but the cleanest fix is to not hand it the bulk in the first place.)
 
 **If a run compacts anyway:** Praxen checkpoints itself. Just before it writes the report, it saves a **draft manifest** to `./reports/<agent-slug>-draft-<timestamp>.md` — a complete record of the analysis (every finding, the RAISE scores, the remit audit). So if you see the auto-compaction notice during a run, or the final report looks thinner than the interim overview Praxen prints to stdout, you have two recovery options:
@@ -183,7 +183,7 @@ The LLM wrote a `findings.json` that didn't pass schema validation, so the deter
 This is usually a context-pressure symptom — the analysis was synthesised under stress and the JSON came out malformed. Options:
 
 - **Re-run** in a larger context window or with a tighter input scope. See *Large workspaces and context sizing* above.
-- **Recover from the draft manifest** if Praxen wrote one (`./reports/<agent-slug>-draft-<timestamp>.md` — Step 9.9 writes this before the JSON). Tell the agent: *"the findings JSON failed validation — read the draft manifest and rebuild from it."*
+- **Recover from the draft manifest** if Praxen wrote one (`./reports/<agent-slug>-draft-<timestamp>.md` — written just before the findings JSON). Tell the agent: *"the findings JSON failed validation — read the draft manifest and rebuild from it."*
 
 If the same JSON-shape error reproduces on a fresh run with plenty of context, that's a Praxen bug — please [file it](https://github.com/open-agent-ai-security/praxen/issues/new/choose) with the schema error and the agent slug.
 
@@ -195,9 +195,9 @@ The skill couldn't find the path you named. Most common causes:
 - **A typo in the filename** — Praxen looks for the exact path you provide; it does not search.
 - **The agent's working directory isn't where you think it is** — re-`cd` and start fresh, or pass an absolute path.
 
-### Mid-analysis context auto-compaction (silent quality loss)
+### Mid-analysis context auto-compaction (easy to miss)
 
-A long scan can exceed the context window and **auto-compact mid-run** — silently, so the run still finishes but findings gathered early get summarised away before the report is written. Symptoms:
+A long scan can exceed the context window and **auto-compact mid-run** — the run still finishes, but findings gathered early can get summarised away before the report is written. It isn't loudly flagged, so it's easy to miss — but there are clear signs:
 
 - The interim overview Praxen prints to stdout names findings the final HTML doesn't include.
 - The HTML report looks suspiciously thin compared to the workspace's complexity.
@@ -213,11 +213,11 @@ Praxen scans typically take 8–15 minutes of wallclock; larger codebases scoped
 - No new files appear in the output directory; any partial JSON on disk is still valid but incomplete.
 - The CLI shows the agent as still running but with no recent tool calls.
 
-What to do: cancel the run and re-invoke against the same target. The chunked-emission protocol the skill follows means the skeleton + early findings persist on disk after each Edit — you won't lose the analysis the agent built up, and a fresh invocation can resume cleanly. Most retries succeed on the first try.
+What to do: cancel the run and re-invoke against the same target. The skill writes its report incrementally, so the skeleton and early findings are already persisted on disk — you won't lose the analysis the agent built up, and a fresh invocation can resume cleanly. Most retries succeed on the first try.
 
 ### Scores look lower than reality
 
-The most common operator surprise — *"my agent is more careful than this report suggests."* In nearly every case, the cause is that the evidence you handed Praxen didn't *show* a control that's actually in place (a review process, a deployment-time limit, an external guardrail, a monitoring pipeline, a red-team cadence). See *Results tuning* above for the additive-evidence workflow.
+The most common operator surprise — *"my agent is more careful than this report suggests."* In nearly every case, the evidence you handed Praxen didn't *show* a control that's actually in place. See [Results tuning](#results-tuning) above for the additive-evidence workflow.
 
 ## Next steps
 

--- a/guide/challenging-findings.html
+++ b/guide/challenging-findings.html
@@ -265,7 +265,7 @@ img { max-width: 100%; display: block; }
 <h2 id="path-1-the-analysis-missed-context">Path 1 — The analysis missed context</h2>
 <p>If the finding is correct given the evidence Praxen saw but wrong because Praxen didn't see something it should have:</p>
 <ul>
-<li><strong>Add the missing evidence to the next analysis.</strong> Point Praxen at the additional directory, log file, or transcript that contains the missing control. Re-run.</li>
+<li><strong>Add the missing evidence to the next analysis.</strong> Point Praxen at the additional directory, log file, or transcript that contains the missing control. Re-run. (See <a href="usage.html#results-tuning">Results tuning</a> for the operational loop, including image/screenshot evidence.)</li>
 <li><strong>Don't loosen the remit just to silence the finding.</strong> A finding that disappears because the remit was weakened is now a real gap that won't be caught next time.</li>
 <li><strong>Document the dependency.</strong> If the missing control lives outside the agent's repository (a sidecar, an upstream gateway, a platform-enforced policy), record this in the remit's <em>Trusted Services / Integrations</em> section and explicitly note that the control is enforced externally. Praxen can then mark the rule as <code>Enforcement Not Possible</code> (in code) rather than as a Gap.</li>
 </ul>

--- a/guide/installation.html
+++ b/guide/installation.html
@@ -241,7 +241,7 @@ img { max-width: 100%; display: block; }
   </div>
 </header>
 <div class="docs-shell">
-  <aside class="docs-sidebar"><nav class="docs-nav"><div class="docs-nav-title">Documentation</div><ul><li><a href="index.html">Overview</a></li><li><a href="installation.html" class="active">Installation</a><ul class="docs-subnav"><li><a href="#prerequisites">Prerequisites</a></li><li><a href="#option-a-claude-code-plugin-marketplace">Option A — Claude Code (plugin marketplace)</a></li><li><a href="#option-b-openai-codex-agent-skill">Option B — OpenAI Codex (agent skill)</a></li><li><a href="#option-c-run-from-an-unzipped-release-either-agent">Option C — Run from an unzipped release (either agent)</a></li><li><a href="#verifying-the-install">Verifying the install</a></li><li><a href="#updating">Updating</a></li><li><a href="#uninstalling">Uninstalling</a></li><li><a href="#next-steps">Next steps</a></li></ul></li><li><a href="quickstart.html">Quickstart</a></li><li><a href="usage.html">Usage</a></li><li><a href="writing-remits.html">Writing Worker Remits</a></li><li><a href="interpreting-reports.html">Interpreting Reports</a></li><li><a href="challenging-findings.html">Challenging Findings</a></li><li><a href="understanding-variability.html">Run-to-Run Variability</a></li><li><a href="abv.html">Agent Behavior Verification</a></li><li><a href="owasp.html">OWASP Gen AI Security</a></li><li><a href="RAISE.html">The RAISE Framework</a></li></ul></nav></aside>
+  <aside class="docs-sidebar"><nav class="docs-nav"><div class="docs-nav-title">Documentation</div><ul><li><a href="index.html">Overview</a></li><li><a href="installation.html" class="active">Installation</a><ul class="docs-subnav"><li><a href="#prerequisites">Prerequisites</a></li><li><a href="#option-a-claude-code-plugin-marketplace">Option A — Claude Code (plugin marketplace)</a></li><li><a href="#option-b-openai-codex-plugin-marketplace">Option B — OpenAI Codex (plugin marketplace)</a></li><li><a href="#option-c-run-from-an-unzipped-release-either-agent">Option C — Run from an unzipped release (either agent)</a></li><li><a href="#verifying-the-install">Verifying the install</a></li><li><a href="#updating">Updating</a></li><li><a href="#uninstalling">Uninstalling</a></li><li><a href="#next-steps">Next steps</a></li></ul></li><li><a href="quickstart.html">Quickstart</a></li><li><a href="usage.html">Usage</a></li><li><a href="writing-remits.html">Writing Worker Remits</a></li><li><a href="interpreting-reports.html">Interpreting Reports</a></li><li><a href="challenging-findings.html">Challenging Findings</a></li><li><a href="understanding-variability.html">Run-to-Run Variability</a></li><li><a href="abv.html">Agent Behavior Verification</a></li><li><a href="owasp.html">OWASP Gen AI Security</a></li><li><a href="RAISE.html">The RAISE Framework</a></li></ul></nav></aside>
   <main class="docs-main">
     <article class="prose"><h1 id="installation">Installation</h1>
 <p>Praxen ships as a portable <strong>agent skill</strong>, packaged for both <strong>Claude Code</strong> and <strong>OpenAI Codex</strong>. Both platforms load the same <code>skills/behavior-verifier</code> engine and produce the same JSON / HTML / TXT report format — only the install/packaging differs. On the same inputs, findings should cover the same major themes, but exact counts, grouping, and RAISE maturity scores can vary by model and context (see <a href="understanding-variability.html">Understanding Run-to-Run Variability</a>). Claude Code is the most common path; Codex is supported as a first-class agent-skills platform.</p>
@@ -260,20 +260,24 @@ claude plugin install praxen@open-agent-ai-security
 claude plugin list      # confirm: praxen@open-agent-ai-security, enabled, v0.8.0+
 </code></pre>
 <p>The skill registers as <code>behavior-verifier</code>. The in-session equivalents — <code>/plugin marketplace add …</code>, <code>/plugin install …</code>, <code>/plugin list</code> — do exactly the same thing; if you install from within a Claude Code session, run <code>/reload-plugins</code> (or restart) to activate the skill. Prefer the terminal form when scripting: <code>claude plugin …</code> is argument-driven and runs the same way on every interface, whereas in-session slash commands occasionally fall through and get sent as ordinary chat messages.</p>
-<h2 id="option-b-openai-codex-agent-skill">Option B — OpenAI Codex (agent skill)</h2>
-<p>Codex discovers skills from a <code>.agents/skills/</code> directory. The first-class path is a <strong>user-wide skill link</strong> — set it up once and every Codex session can invoke Praxen, from any directory:</p>
+<h2 id="option-b-openai-codex-plugin-marketplace">Option B — OpenAI Codex (plugin marketplace)</h2>
+<p>Codex has its own plugin marketplace, and Praxen installs from the <strong>same repo</strong> as the Claude Code path. From your terminal:</p>
+<pre><code class="language-bash">codex plugin marketplace add open-agent-ai-security/praxen
+codex plugin add praxen@open-agent-ai-security
+codex plugin list      # confirm: praxen@open-agent-ai-security, installed, enabled, v1.0.0+
+</code></pre>
+<p>Codex surfaces the bundled skill to the model as <strong><code>praxen:behavior-verifier</code></strong> — the plugin-qualified <code>plugin:skill</code> id, the same shape Codex uses for its own first-party skills (<code>pdf</code>, <code>presentations</code>, …). Invoke it by naming that skill and pointing Codex at a target. Praxen needs workspace writes (it creates <code>./reports/</code> and runs two bundled Python scripts), so run <code>codex exec</code> with a workspace-write sandbox:</p>
+<pre><code class="language-bash">codex exec --sandbox workspace-write -C /path/to/scan-dir \
+  'Use the praxen:behavior-verifier skill. Run a Praxen behavior analysis against ./target. Use the Worker Remit at ./WORKER_REMIT.md. Write outputs to ./reports/.'
+</code></pre>
+<p>That's the whole happy path; for an end-to-end first run, see <a href="quickstart.html">Quickstart</a>.</p>
+<h3 id="alternative-link-the-skill-folder-directly">Alternative — link the skill folder directly</h3>
+<p>No marketplace required: Codex also discovers skills from an <code>.agents/skills/</code> directory. A <strong>user-wide skill link</strong> makes Praxen available from every Codex session, from any directory:</p>
 <pre><code class="language-bash">cd /path/to/praxen          # your checkout or unzipped release (Option C)
 mkdir -p &quot;$HOME/.agents/skills&quot;
 ln -sfn &quot;$PWD/skills/behavior-verifier&quot; &quot;$HOME/.agents/skills/behavior-verifier&quot;
 </code></pre>
-<p>Codex surfaces the skill as <strong><code>praxen:behavior-verifier</code></strong> — invoke it by that plugin-qualified name (<code>$praxen:behavior-verifier</code>, not <code>$behavior-verifier</code>) and point it at a target. Praxen needs workspace writes (it creates <code>./reports/</code> and runs two bundled Python scripts), so run <code>codex exec</code> with a workspace-write sandbox:</p>
-<pre><code class="language-bash">codex exec --sandbox workspace-write -C /path/to/scan-dir \
-  'Use $praxen:behavior-verifier. Run a Praxen behavior analysis against ./target. Use the Worker Remit at ./WORKER_REMIT.md. Write outputs to ./reports/.'
-</code></pre>
-<p>That's the whole happy path; for an end-to-end first run, see <a href="quickstart.html">Quickstart</a>. (To scope the skill to a single project instead of user-wide, link it into that repo's own <code>.agents/skills/</code>. A public Codex <em>marketplace</em> install mirroring Option A is <a href="https://github.com/open-agent-ai-security/praxen/issues/102">tracked as a future enhancement</a>, not yet available.)</p>
-<blockquote>
-<p><strong>Two Codex gotchas.</strong> <code>codex exec -C &lt;dir&gt;</code> refuses to run outside a trusted git repo (<code>Not inside a trusted directory…</code>) — run from a git checkout, or add <code>--skip-git-repo-check</code>. And on load Codex may print warnings about <em>other</em> installed plugins or a telemetry metric-tag on the <code>praxen:behavior-verifier</code> id; those are Codex-side and don't affect the scan.</p>
-</blockquote>
+<p>To scope the skill to a single project instead, link it into that repo's own <code>.agents/skills/</code>.</p>
 <h2 id="option-c-run-from-an-unzipped-release-either-agent">Option C — Run from an unzipped release (either agent)</h2>
 <p>If you can't or don't want to use a marketplace flow, unzip the release archive somewhere your coding agent can see it. There's no install step — the archive carries both the <code>.claude-plugin/</code> and <code>.codex-plugin/</code> manifests plus the shared <code>skills/</code> engine.</p>
 <pre><code class="language-bash"># Replace VERSION with the release tag and RELEASE_URL with the .zip asset URL
@@ -287,7 +291,7 @@ cd praxen-VERSION
 <pre><code class="language-bash">claude plugin list
 </code></pre>
 <p>If <code>praxen@open-agent-ai-security</code> appears at <code>v0.8.0</code> or later with <code>enabled</code>, the marketplace install is working. From within a session the same plugin shows under <code>/plugin list</code>, and the skill is invocable as <code>behavior-verifier</code>.</p>
-<p><strong>Codex:</strong> confirm the skill appears to the model as <code>praxen:behavior-verifier</code> in Codex's skill list. That's the parity check — it confirms discovery, the same way <code>claude plugin list</code> does for Claude Code.</p>
+<p><strong>Codex (marketplace):</strong> run <code>codex plugin list</code> — if <code>praxen@open-agent-ai-security</code> shows <code>installed, enabled</code> at <code>v1.0.0</code> or later, the install is working. Inside a session the skill appears to the model as <code>praxen:behavior-verifier</code> (or browse with <code>/skills</code>). That's the parity check, the same way <code>claude plugin list</code> is for Claude Code.</p>
 <p>For the first <strong>end-to-end run</strong> — declared intent → evidence → HTML / JSON / TXT report — see <a href="quickstart.html">Quickstart</a>. It walks through having Claude author a Worker Remit for the FinBot demo agent, scan the code against it, and read the report, in about 15 minutes — all from plain-English instructions.</p>
 <h2 id="updating">Updating</h2>
 <p>Every Praxen release bumps the version string, so a new version is always picked up once you refresh — the only question is whether you refresh by hand or let Claude Code do it for you. Check what you currently have with:</p>
@@ -320,15 +324,25 @@ claude plugin update praxen@open-agent-ai-security         # install the latest 
 <blockquote>
 <p>Because Praxen is a security tool, staying current matters — enabling auto-update (or updating on a regular cadence) is recommended.</p>
 </blockquote>
-<h3 id="openai-codex-unzipped-release">OpenAI Codex / unzipped release</h3>
-<p>There's no marketplace, so updating is manual: <code>git pull</code> the checkout (a symlinked skill folder picks up the new version automatically), or download the new release zip and replace it. There's no migration step; Praxen is stateless across analyses.</p>
+<h3 id="openai-codex-marketplace">OpenAI Codex — marketplace</h3>
+<p>Refresh the catalog snapshot, then re-install — the same two-step shape as Claude Code:</p>
+<pre><code class="language-bash">codex plugin marketplace upgrade open-agent-ai-security   # refresh the snapshot from the repo
+codex plugin add praxen@open-agent-ai-security             # install the refreshed version
+</code></pre>
+<p>(If <code>codex plugin add</code> reports the plugin is already installed, run <code>codex plugin remove praxen@open-agent-ai-security</code> first, then add again.)</p>
+<h3 id="openai-codex-skill-link-unzipped-release">OpenAI Codex (skill link) / unzipped release</h3>
+<p>If you linked the skill folder or run from an unzipped release, updating is manual: <code>git pull</code> the checkout (a symlinked skill folder picks up the new version automatically), or download the new release zip and replace it. There's no migration step; Praxen is stateless across analyses.</p>
 <h2 id="uninstalling">Uninstalling</h2>
 <p><strong>Claude Code (plugin marketplace):</strong></p>
 <pre><code class="language-bash">claude plugin uninstall praxen@open-agent-ai-security
 claude plugin marketplace remove open-agent-ai-security
 </code></pre>
 <p>The marketplace is removed by its registered name (<code>open-agent-ai-security</code>, from <code>.claude-plugin/marketplace.json</code>) — which here matches the repo owner used to add it.</p>
-<p><strong>OpenAI Codex:</strong> remove the skill link — <code>rm .agents/skills/behavior-verifier</code> (or <code>rm ~/.agents/skills/behavior-verifier</code>).</p>
+<p><strong>OpenAI Codex (marketplace):</strong></p>
+<pre><code class="language-bash">codex plugin remove praxen@open-agent-ai-security
+codex plugin marketplace remove open-agent-ai-security
+</code></pre>
+<p><strong>OpenAI Codex (skill link):</strong> remove the link — <code>rm .agents/skills/behavior-verifier</code> (or <code>rm ~/.agents/skills/behavior-verifier</code>).</p>
 <p><strong>Unzipped release:</strong> delete the directory. No system state is left behind.</p>
 <h2 id="next-steps">Next steps</h2>
 <ul>

--- a/guide/installation.html
+++ b/guide/installation.html
@@ -241,58 +241,38 @@ img { max-width: 100%; display: block; }
   </div>
 </header>
 <div class="docs-shell">
-  <aside class="docs-sidebar"><nav class="docs-nav"><div class="docs-nav-title">Documentation</div><ul><li><a href="index.html">Overview</a></li><li><a href="installation.html" class="active">Installation</a><ul class="docs-subnav"><li><a href="#prerequisites">Prerequisites</a></li><li><a href="#option-a-claude-code-plugin-marketplace">Option A — Claude Code (plugin marketplace)</a></li><li><a href="#option-b-openai-codex-plugin-marketplace">Option B — OpenAI Codex (plugin marketplace)</a></li><li><a href="#option-c-run-from-an-unzipped-release-either-agent">Option C — Run from an unzipped release (either agent)</a></li><li><a href="#verifying-the-install">Verifying the install</a></li><li><a href="#updating">Updating</a></li><li><a href="#uninstalling">Uninstalling</a></li><li><a href="#next-steps">Next steps</a></li></ul></li><li><a href="quickstart.html">Quickstart</a></li><li><a href="usage.html">Usage</a></li><li><a href="writing-remits.html">Writing Worker Remits</a></li><li><a href="interpreting-reports.html">Interpreting Reports</a></li><li><a href="challenging-findings.html">Challenging Findings</a></li><li><a href="understanding-variability.html">Run-to-Run Variability</a></li><li><a href="abv.html">Agent Behavior Verification</a></li><li><a href="owasp.html">OWASP Gen AI Security</a></li><li><a href="RAISE.html">The RAISE Framework</a></li></ul></nav></aside>
+  <aside class="docs-sidebar"><nav class="docs-nav"><div class="docs-nav-title">Documentation</div><ul><li><a href="index.html">Overview</a></li><li><a href="installation.html" class="active">Installation</a><ul class="docs-subnav"><li><a href="#prerequisites">Prerequisites</a></li><li><a href="#claude-code">Claude Code</a></li><li><a href="#openai-codex">OpenAI Codex</a></li><li><a href="#any-other-agent">Any other agent</a></li><li><a href="#updating">Updating</a></li><li><a href="#uninstalling">Uninstalling</a></li><li><a href="#next-steps">Next steps</a></li></ul></li><li><a href="quickstart.html">Quickstart</a></li><li><a href="usage.html">Usage</a></li><li><a href="writing-remits.html">Writing Worker Remits</a></li><li><a href="interpreting-reports.html">Interpreting Reports</a></li><li><a href="challenging-findings.html">Challenging Findings</a></li><li><a href="understanding-variability.html">Run-to-Run Variability</a></li><li><a href="abv.html">Agent Behavior Verification</a></li><li><a href="owasp.html">OWASP Gen AI Security</a></li><li><a href="RAISE.html">The RAISE Framework</a></li></ul></nav></aside>
   <main class="docs-main">
     <article class="prose"><h1 id="installation">Installation</h1>
 <p>Praxen ships as a portable <strong>agent skill</strong>, packaged for both <strong>Claude Code</strong> and <strong>OpenAI Codex</strong>. Both platforms load the same <code>skills/behavior-verifier</code> engine and produce the same JSON / HTML / TXT report format — only the install/packaging differs. On the same inputs, findings should cover the same major themes, but exact counts, grouping, and RAISE maturity scores can vary by model and context (see <a href="understanding-variability.html">Understanding Run-to-Run Variability</a>). Claude Code is the most common path; Codex is supported as a first-class agent-skills platform.</p>
 <h2 id="prerequisites">Prerequisites</h2>
 <ul>
 <li><strong>A coding agent</strong> capable of tool use and multi-step instruction-following. Praxen is tested against <a href="https://docs.claude.com/en/docs/claude-code/overview">Claude Code</a> and <a href="https://developers.openai.com/codex/skills">OpenAI Codex</a>; other coding agents that can read a skill markdown file and call tools (Read, Grep, Glob, Bash, Write) should also work.</li>
-<li><strong>Python 3.9 or newer on the PATH.</strong> Praxen's report renderer (<code>render.py</code>, bundled with the skill) is plain Python 3 — standard library only, nothing to <code>pip install</code>. 3.9 is the macOS Command Line Tools system Python (Ventura / Sonoma / Sequoia), so on macOS there's typically nothing to install. On Windows, <code>py -3</code> works. If <code>python3</code> isn't found, the renderer step falls back to <code>python</code>.</li>
+<li><strong>Python 3.9 or newer on the PATH</strong> — for the bundled report renderer (<code>render.py</code>), which is standard-library only (nothing to <code>pip install</code>). You almost certainly already have it: 3.9 ships as the macOS Command Line Tools system Python, and on Windows <code>py -3</code> works. (If <code>python3</code> isn't found, the renderer falls back to <code>python</code>.)</li>
 <li><strong>Network access for your coding agent's LLM provider</strong> during analysis. Praxen itself does not phone home, but the LLM calls your coding agent makes during analysis follow whatever provider configuration the agent uses.</li>
-<li><strong>Workspace write permission for the agent.</strong> Praxen writes its report files to a <code>./reports/</code> directory and runs two bundled Python scripts during a scan, so the agent must be allowed to write within the working directory (the default in Claude Code; on Codex, run with a workspace-write sandbox — see below).</li>
+<li><strong>Workspace write permission for the agent.</strong> Praxen writes its report files to a <code>./reports/</code> directory and runs two bundled Python scripts during a scan, so the agent must be allowed to write within the working directory. Claude Code allows this by default; agents that sandbox file writes need that permission granted (per your agent's own docs).</li>
 </ul>
 <p>That's the entire dependency surface.</p>
-<h2 id="option-a-claude-code-plugin-marketplace">Option A — Claude Code (plugin marketplace)</h2>
-<p>The recommended path for Claude Code users. From your terminal:</p>
+<h2 id="claude-code">Claude Code</h2>
+<p>Install from the plugin marketplace. From your terminal:</p>
 <pre><code class="language-bash">claude plugin marketplace add open-agent-ai-security/praxen
 claude plugin install praxen@open-agent-ai-security
-claude plugin list      # confirm: praxen@open-agent-ai-security, enabled, v0.8.0+
+claude plugin list      # confirm: praxen@open-agent-ai-security, enabled, v1.0.0+
 </code></pre>
 <p>The skill registers as <code>behavior-verifier</code>. The in-session equivalents — <code>/plugin marketplace add …</code>, <code>/plugin install …</code>, <code>/plugin list</code> — do exactly the same thing; if you install from within a Claude Code session, run <code>/reload-plugins</code> (or restart) to activate the skill. Prefer the terminal form when scripting: <code>claude plugin …</code> is argument-driven and runs the same way on every interface, whereas in-session slash commands occasionally fall through and get sent as ordinary chat messages.</p>
-<h2 id="option-b-openai-codex-plugin-marketplace">Option B — OpenAI Codex (plugin marketplace)</h2>
+<h2 id="openai-codex">OpenAI Codex</h2>
 <p>Codex has its own plugin marketplace, and Praxen installs from the <strong>same repo</strong> as the Claude Code path. From your terminal:</p>
 <pre><code class="language-bash">codex plugin marketplace add open-agent-ai-security/praxen
 codex plugin add praxen@open-agent-ai-security
 codex plugin list      # confirm: praxen@open-agent-ai-security, installed, enabled, v1.0.0+
 </code></pre>
-<p>Codex surfaces the bundled skill to the model as <strong><code>praxen:behavior-verifier</code></strong> — the plugin-qualified <code>plugin:skill</code> id, the same shape Codex uses for its own first-party skills (<code>pdf</code>, <code>presentations</code>, …). Invoke it by naming that skill and pointing Codex at a target. Praxen needs workspace writes (it creates <code>./reports/</code> and runs two bundled Python scripts), so run <code>codex exec</code> with a workspace-write sandbox:</p>
-<pre><code class="language-bash">codex exec --sandbox workspace-write -C /path/to/scan-dir \
-  'Use the praxen:behavior-verifier skill. Run a Praxen behavior analysis against ./target. Use the Worker Remit at ./WORKER_REMIT.md. Write outputs to ./reports/.'
-</code></pre>
-<p>That's the whole happy path; for an end-to-end first run, see <a href="quickstart.html">Quickstart</a>.</p>
-<h3 id="alternative-link-the-skill-folder-directly">Alternative — link the skill folder directly</h3>
-<p>No marketplace required: Codex also discovers skills from an <code>.agents/skills/</code> directory. A <strong>user-wide skill link</strong> makes Praxen available from every Codex session, from any directory:</p>
-<pre><code class="language-bash">cd /path/to/praxen          # your checkout or unzipped release (Option C)
-mkdir -p &quot;$HOME/.agents/skills&quot;
-ln -sfn &quot;$PWD/skills/behavior-verifier&quot; &quot;$HOME/.agents/skills/behavior-verifier&quot;
-</code></pre>
-<p>To scope the skill to a single project instead, link it into that repo's own <code>.agents/skills/</code>.</p>
-<h2 id="option-c-run-from-an-unzipped-release-either-agent">Option C — Run from an unzipped release (either agent)</h2>
-<p>If you can't or don't want to use a marketplace flow, unzip the release archive somewhere your coding agent can see it. There's no install step — the archive carries both the <code>.claude-plugin/</code> and <code>.codex-plugin/</code> manifests plus the shared <code>skills/</code> engine.</p>
-<pre><code class="language-bash"># Replace VERSION with the release tag and RELEASE_URL with the .zip asset URL
-curl -L -o praxen-VERSION.zip RELEASE_URL
-unzip praxen-VERSION.zip
-cd praxen-VERSION
-</code></pre>
-<p>Then point your coding agent at <code>skills/behavior-verifier/SKILL.md</code> (Claude Code), or link it into <code>.agents/skills/</code> and invoke <code>$praxen:behavior-verifier</code> (Codex, per Option B). See <a href="usage.html">Usage</a>.</p>
-<h2 id="verifying-the-install">Verifying the install</h2>
-<p><strong>Claude Code:</strong></p>
-<pre><code class="language-bash">claude plugin list
-</code></pre>
-<p>If <code>praxen@open-agent-ai-security</code> appears at <code>v0.8.0</code> or later with <code>enabled</code>, the marketplace install is working. From within a session the same plugin shows under <code>/plugin list</code>, and the skill is invocable as <code>behavior-verifier</code>.</p>
-<p><strong>Codex (marketplace):</strong> run <code>codex plugin list</code> — if <code>praxen@open-agent-ai-security</code> shows <code>installed, enabled</code> at <code>v1.0.0</code> or later, the install is working. Inside a session the skill appears to the model as <code>praxen:behavior-verifier</code> (or browse with <code>/skills</code>). That's the parity check, the same way <code>claude plugin list</code> is for Claude Code.</p>
-<p>For the first <strong>end-to-end run</strong> — declared intent → evidence → HTML / JSON / TXT report — see <a href="quickstart.html">Quickstart</a>. It walks through having Claude author a Worker Remit for the FinBot demo agent, scan the code against it, and read the report, in about 15 minutes — all from plain-English instructions.</p>
+<p>This installs and enables the plugin in Codex's local config; the bundled <code>behavior-verifier</code> skill is then available to every Codex session. Running an analysis is the same as on any agent — see <a href="usage.html">Usage</a>.</p>
+<h2 id="any-other-agent">Any other agent</h2>
+<p>No marketplace, no download step — Praxen is just a skill folder in a public repo, so any capable coding agent can fetch and run it from a plain-English instruction. (This also works on Claude Code or Codex if you'd rather skip the marketplace.) In your agent session, say something like:</p>
+<blockquote>
+<p>Clone <code>https://github.com/open-agent-ai-security/praxen</code> and follow its <code>behavior-verifier</code> skill to run a Praxen behavior analysis on [your target]. Use the Worker Remit at [path].</p>
+</blockquote>
+<p>The agent brings down its own copy and runs the skill from <code>skills/behavior-verifier/</code>. Offline? Download the release <code>.zip</code> from the <a href="https://github.com/open-agent-ai-security/praxen/releases">releases page</a> and point your agent at the unzipped folder instead. See <a href="usage.html">Usage</a> for the analysis instructions.</p>
 <h2 id="updating">Updating</h2>
 <p>Every Praxen release bumps the version string, so a new version is always picked up once you refresh — the only question is whether you refresh by hand or let Claude Code do it for you. Check what you currently have with:</p>
 <pre><code class="language-bash">claude plugin list      # shows praxen@open-agent-ai-security and its installed version
@@ -329,9 +309,8 @@ claude plugin update praxen@open-agent-ai-security         # install the latest 
 <pre><code class="language-bash">codex plugin marketplace upgrade open-agent-ai-security   # refresh the snapshot from the repo
 codex plugin add praxen@open-agent-ai-security             # install the refreshed version
 </code></pre>
-<p>(If <code>codex plugin add</code> reports the plugin is already installed, run <code>codex plugin remove praxen@open-agent-ai-security</code> first, then add again.)</p>
-<h3 id="openai-codex-skill-link-unzipped-release">OpenAI Codex (skill link) / unzipped release</h3>
-<p>If you linked the skill folder or run from an unzipped release, updating is manual: <code>git pull</code> the checkout (a symlinked skill folder picks up the new version automatically), or download the new release zip and replace it. There's no migration step; Praxen is stateless across analyses.</p>
+<h3 id="any-other-agent_1">Any other agent</h3>
+<p>Tell the agent to <code>git pull</code> its clone (or re-clone), or download a newer release <code>.zip</code>. There's no migration step — Praxen is stateless across analyses.</p>
 <h2 id="uninstalling">Uninstalling</h2>
 <p><strong>Claude Code (plugin marketplace):</strong></p>
 <pre><code class="language-bash">claude plugin uninstall praxen@open-agent-ai-security
@@ -342,8 +321,7 @@ claude plugin marketplace remove open-agent-ai-security
 <pre><code class="language-bash">codex plugin remove praxen@open-agent-ai-security
 codex plugin marketplace remove open-agent-ai-security
 </code></pre>
-<p><strong>OpenAI Codex (skill link):</strong> remove the link — <code>rm .agents/skills/behavior-verifier</code> (or <code>rm ~/.agents/skills/behavior-verifier</code>).</p>
-<p><strong>Unzipped release:</strong> delete the directory. No system state is left behind.</p>
+<p><strong>Any other agent:</strong> delete the cloned (or unzipped) folder. No system state is left behind.</p>
 <h2 id="next-steps">Next steps</h2>
 <ul>
 <li><a href="quickstart.html">Quickstart</a> — first end-to-end report: have Claude author a remit for the FinBot demo agent, scan it, and read the report</li>

--- a/guide/quickstart.html
+++ b/guide/quickstart.html
@@ -248,7 +248,7 @@ img { max-width: 100%; display: block; }
 <p>This walkthrough uses <strong>Claude Code</strong>; <strong>OpenAI Codex</strong> works the same way — wherever it says <code>claude</code> or "ask Claude," substitute your Codex invocation, and the steps are identical.</p>
 <p>You do very little here — four short instructions; Claude does the work: fetching docs, writing the policy, cloning the code, running the analysis, and rendering the report. Budget about 15 minutes, most of it Claude thinking while you watch.</p>
 <blockquote>
-<p>Not installed yet? Do <a href="installation.html">Installation</a> first — one marketplace command on Claude Code, or a one-line skill link on Codex. There's nothing else to clone or download; Claude pulls what it needs.</p>
+<p>Not installed yet? Do <a href="installation.html">Installation</a> first — one marketplace command on Claude Code or Codex. There's nothing else to clone or download; Claude pulls what it needs.</p>
 </blockquote>
 <h2 id="set-up">Set up</h2>
 <p>Start a Claude Code session in a fresh, empty folder — that's where the remit and the <code>reports/</code> will land:</p>

--- a/guide/usage.html
+++ b/guide/usage.html
@@ -245,7 +245,7 @@ img { max-width: 100%; display: block; }
   <main class="docs-main">
     <article class="prose"><h1 id="usage">Usage</h1>
 <p>Running a Praxen analysis takes two inputs: a <strong>Worker Remit</strong> (the agent's declared policy) and <strong>evidence</strong> (whatever the agent's code, deployment state, behavioral records, or development/governance docs can provide). Praxen produces three output files in <code>./reports/</code>.</p>
-<p><strong>Praxen is designed as a read-only external observer.</strong> It reads the artifacts you point it at and writes a local report; it does not modify the agent, sit in its control path, or call any service Praxen itself controls. This read-only posture is a discipline of the skill's instructions rather than a technical sandbox — the analysis runs with the coding agent's ordinary Bash/Write access — but it keeps Praxen suitable as an independent verifier, not self-attestation by the agent under analysis.</p>
+<p><strong>Praxen is designed as a read-only external observer.</strong> It reads the artifacts you point it at and writes a local report; it does not modify the agent, sit in its control path, or call any service Praxen itself controls. This read-only posture is a discipline of the skill's instructions, not a technical sandbox: the analysis runs with the coding agent's ordinary Bash/Write access. That discipline is what keeps Praxen an independent verifier, rather than self-attestation by the agent under analysis.</p>
 <p>This page covers the end-to-end run. For installing Praxen, see <a href="installation.html">Installation</a>. For authoring the Worker Remit, see <a href="writing-remits.html">Writing Worker Remits</a>. For the verification model Praxen implements, see <a href="abv.html">Agent Behavior Verification</a>.</p>
 <h2 id="the-two-inputs">The two inputs</h2>
 <h3 id="worker-remit">Worker Remit</h3>
@@ -281,7 +281,7 @@ img { max-width: 100%; display: block; }
 </table>
 <p>You can provide more than one shape in the same analysis — for example, source code plus a recent action log plus the team's red-team report. Coverage and confidence increase with each additional input shape.</p>
 <h2 id="running-an-analysis">Running an analysis</h2>
-<p>From a Claude Code session (or any coding agent capable of running the skill):</p>
+<p>From inside your coding-agent session — Claude Code, Codex, or any agent that can run the skill — it's the same plain-English instruction:</p>
 <pre><code>Please run the behavior-verifier skill to analyze [path to evidence]. Use the Worker Remit at [path to remit].
 </code></pre>
 <h3 id="invoking-by-evidence-type">Invoking by evidence type</h3>
@@ -306,13 +306,13 @@ Use the Worker Remit at ./WORKER_REMIT.md.
 </code></pre>
 <p>Coverage and confidence increase with each additional input shape — see the <a href="#evidence">Evidence</a> table above for what each contributes.</p>
 <h3 id="for-highest-scan-fidelity-run-in-a-fresh-context">For highest scan fidelity: run in a fresh context</h3>
-<p>A scan run in the same session that explored the workspace earlier (while authoring the remit, reading code, or doing prep work) will systematically <strong>under-read</strong> during the Step 4 artifact sweep — the scanner pattern-matches against what it already knows rather than doing a full cold discovery. On a large codebase the gap is real: a cold-context scan reads materially more of the workspace, and that extra evidence can move RAISE scores upward — so a warm-context scan tends to <em>under</em>-report.</p>
-<p><strong>The recommended approach for a high-confidence scan:</strong> spawn a subagent with no prior context and point it at the workspace. In Claude Code, the Agent tool sends a fresh instance with no conversation history:</p>
+<p>A scan run in the same session that explored the workspace earlier (while authoring the remit, reading code, or doing prep work) will systematically <strong>under-read</strong> during the artifact sweep — the scanner pattern-matches against what it already knows rather than doing a full cold discovery. On a large codebase the gap is real: a cold-context scan reads materially more of the workspace, and that extra evidence can move RAISE scores upward — so a warm-context scan tends to <em>under</em>-report.</p>
+<p><strong>The recommended approach for a high-confidence scan:</strong> run it in a subagent or a fresh session that carries no prior context, and point it at the workspace:</p>
 <pre><code>Please spawn a subagent with no prior context to run the behavior-verifier skill
 against ./my-agent-repo/. Worker Remit is at ./WORKER_REMIT.md. Output to
 ./reports/.
 </code></pre>
-<p>This is also the right pattern when the scan follows a remit-authoring session — if Praxen drafted the remit and then immediately scans, the same context holds everything it just read, and Step 4 will be shallow. Finish the remit, confirm it, then start a fresh scan session.</p>
+<p>This is also the right pattern when the scan follows a remit-authoring session — if Praxen drafted the remit and then immediately scans, the same context holds everything it just read, and the artifact sweep will be shallow. Finish the remit, confirm it, then start a fresh scan session.</p>
 <p>Praxen reads the evidence, evaluates it against the RAISE Framework and the Worker Remit, and writes three files to <code>./reports/</code>:</p>
 <table>
 <thead>
@@ -347,8 +347,8 @@ against ./my-agent-repo/. Worker Remit is at ./WORKER_REMIT.md. Output to
 </code></pre>
 <p>A new pair of timestamped files is written. Prior reports are not overwritten — you can compare runs by diffing the <code>findings-&lt;date&gt;.json</code> files or by opening multiple HTML reports side by side.</p>
 <h2 id="results-tuning">Results tuning</h2>
-<p>Praxen only scores what it can see. If you disagree with a finding — especially a RAISE category score that feels lower than reality — the usual cause is that the evidence you handed it didn't <em>show</em> a control that's actually in place: a review process, a deployment-time limit, an external guardrail, a monitoring pipeline, a red-team cadence. Praxen won't assume those exist; it scores absence of evidence as absence of control (see the calibration anchors — present-but-undocumented and present-but-defeated both land low).</p>
-<p>The fix is to give it more evidence and re-run. Add whatever artifact demonstrates the control — a runbook, a CI config, a policy doc, a red-team report, a ticket history, an exported dashboard config, even a written description of the process — and ask Praxen to factor it in:</p>
+<p>Praxen only scores what it can see. If a finding — or a RAISE category score — feels lower than reality, the usual cause is simple: the evidence you handed it didn't <em>show</em> a control that's actually in place (a review process, a deployment-time limit, an external guardrail, a monitoring pipeline, a red-team cadence).</p>
+<p>The fix is to show it — add whatever artifact demonstrates the control (a runbook, a CI config, a policy doc, a red-team report, a ticket history, an exported dashboard config, even a written description of the process) and ask Praxen to factor it in:</p>
 <pre><code>Here's our red-team report and the production alerting config. Please re-run the
 behavior-verifier skill against the same workspace and remit, and factor these in.
 </code></pre>
@@ -362,13 +362,13 @@ behavior-verifier skill against the same workspace and remit, and factor these i
 <li><strong>Cron / launchd</strong> — run nightly against a deployed agent's exported state.</li>
 <li><strong>GitHub Action</strong> — run on a schedule and post the <code>.txt</code> summary as a comment.</li>
 </ul>
-<p>Because Praxen is stateless and produces deterministic outputs (modulo timestamp), CI integration is straightforward. The JSON output is the right format for automated downstream consumers.</p>
+<p>Because Praxen is stateless and emits machine-readable JSON, CI integration is straightforward. The JSON output is the right format for automated downstream consumers.</p>
 <h2 id="large-workspaces-and-context-sizing">Large workspaces and context sizing</h2>
-<p>A Praxen analysis is read-heavy: it loads the skill procedure, the knowledge bases, and every artifact in the workspace, holds the findings in working memory, and writes the report in a single synthesis pass. On a large target this can exceed the coding agent's context window, and the session <strong>auto-compacts mid-analysis</strong>. That failure is silent — you still get a report, but findings gathered early in the run can be lost or over-summarized by the compaction before the report is written. The goal is to keep the whole scan inside one context window.</p>
+<p>A Praxen analysis is read-heavy: it loads the skill procedure, the knowledge bases, and every artifact in the workspace, holds the findings in working memory, and writes the report in a single synthesis pass. On a large target this can exceed the coding agent's context window, and the session <strong>auto-compacts mid-analysis</strong> — which can thin or over-summarize findings gathered early in the run before the report is written. It's recoverable, not catastrophic: Praxen checkpoints the full analysis to disk just before rendering (the draft manifest, below), and a compacted run leaves visible signs — a compaction notice during the run, and a final report that reads thinner than the interim summary Praxen prints to stdout. Still, the cleanest result comes from keeping the whole scan inside one context window.</p>
 <p><strong>To keep a scan inside the window:</strong></p>
 <ol>
 <li><strong>Use the largest context window available.</strong> This is the biggest lever. In Claude Code, run the analysis in the largest-context session you have access to — a 1M-context (Opus) session if you have one. A 200k-class window can compact partway through a non-trivial agent scan once the procedure, knowledge bases, file reads, and synthesis are all resident at once.</li>
-<li><strong>Start a fresh session for the scan.</strong> Don't run Praxen at the tail of a long conversation that has already consumed most of the window — give the analysis the full budget. A fresh session also gives you a better scan: prior workspace familiarity causes Step 4 to under-read (see <em>For highest scan fidelity</em> above).</li>
+<li><strong>Start a fresh session for the scan.</strong> Don't run Praxen at the tail of a long conversation that has already consumed most of the window — give the analysis the full budget. A fresh session also gives you a better scan: prior workspace familiarity causes the artifact sweep to under-read (see <em>For highest scan fidelity</em> above).</li>
 <li><strong>Scope the input to the agent, not the whole repo.</strong> Point Praxen at the agent's core surface — its prompts, skill files, code, config, and the Worker Remit — and leave out what isn't the agent: <code>node_modules</code> and vendored dependencies, <code>.git</code>, <code>dist</code> / <code>build</code> output, large data and log files, test fixtures. The Worker Remit defines what's in scope; the input path should match. (Praxen already samples large logs and lockfiles rather than reading them whole — but the cleanest fix is to not hand it the bulk in the first place.)</li>
 </ol>
 <p><strong>If a run compacts anyway:</strong> Praxen checkpoints itself. Just before it writes the report, it saves a <strong>draft manifest</strong> to <code>./reports/&lt;agent-slug&gt;-draft-&lt;timestamp&gt;.md</code> — a complete record of the analysis (every finding, the RAISE scores, the remit audit). So if you see the auto-compaction notice during a run, or the final report looks thinner than the interim overview Praxen prints to stdout, you have two recovery options:</p>
@@ -392,7 +392,7 @@ behavior-verifier skill against the same workspace and remit, and factor these i
 <p>This is usually a context-pressure symptom — the analysis was synthesised under stress and the JSON came out malformed. Options:</p>
 <ul>
 <li><strong>Re-run</strong> in a larger context window or with a tighter input scope. See <em>Large workspaces and context sizing</em> above.</li>
-<li><strong>Recover from the draft manifest</strong> if Praxen wrote one (<code>./reports/&lt;agent-slug&gt;-draft-&lt;timestamp&gt;.md</code> — Step 9.9 writes this before the JSON). Tell the agent: <em>"the findings JSON failed validation — read the draft manifest and rebuild from it."</em></li>
+<li><strong>Recover from the draft manifest</strong> if Praxen wrote one (<code>./reports/&lt;agent-slug&gt;-draft-&lt;timestamp&gt;.md</code> — written just before the findings JSON). Tell the agent: <em>"the findings JSON failed validation — read the draft manifest and rebuild from it."</em></li>
 </ul>
 <p>If the same JSON-shape error reproduces on a fresh run with plenty of context, that's a Praxen bug — please <a href="https://github.com/open-agent-ai-security/praxen/issues/new/choose">file it</a> with the schema error and the agent slug.</p>
 <h3 id="worker-remit-not-found-no-remit-at-that-path">"Worker Remit not found" / "no remit at that path"</h3>
@@ -402,8 +402,8 @@ behavior-verifier skill against the same workspace and remit, and factor these i
 <li><strong>A typo in the filename</strong> — Praxen looks for the exact path you provide; it does not search.</li>
 <li><strong>The agent's working directory isn't where you think it is</strong> — re-<code>cd</code> and start fresh, or pass an absolute path.</li>
 </ul>
-<h3 id="mid-analysis-context-auto-compaction-silent-quality-loss">Mid-analysis context auto-compaction (silent quality loss)</h3>
-<p>A long scan can exceed the context window and <strong>auto-compact mid-run</strong> — silently, so the run still finishes but findings gathered early get summarised away before the report is written. Symptoms:</p>
+<h3 id="mid-analysis-context-auto-compaction-easy-to-miss">Mid-analysis context auto-compaction (easy to miss)</h3>
+<p>A long scan can exceed the context window and <strong>auto-compact mid-run</strong> — the run still finishes, but findings gathered early can get summarised away before the report is written. It isn't loudly flagged, so it's easy to miss — but there are clear signs:</p>
 <ul>
 <li>The interim overview Praxen prints to stdout names findings the final HTML doesn't include.</li>
 <li>The HTML report looks suspiciously thin compared to the workspace's complexity.</li>
@@ -417,9 +417,9 @@ behavior-verifier skill against the same workspace and remit, and factor these i
 <li>No new files appear in the output directory; any partial JSON on disk is still valid but incomplete.</li>
 <li>The CLI shows the agent as still running but with no recent tool calls.</li>
 </ul>
-<p>What to do: cancel the run and re-invoke against the same target. The chunked-emission protocol the skill follows means the skeleton + early findings persist on disk after each Edit — you won't lose the analysis the agent built up, and a fresh invocation can resume cleanly. Most retries succeed on the first try.</p>
+<p>What to do: cancel the run and re-invoke against the same target. The skill writes its report incrementally, so the skeleton and early findings are already persisted on disk — you won't lose the analysis the agent built up, and a fresh invocation can resume cleanly. Most retries succeed on the first try.</p>
 <h3 id="scores-look-lower-than-reality">Scores look lower than reality</h3>
-<p>The most common operator surprise — <em>"my agent is more careful than this report suggests."</em> In nearly every case, the cause is that the evidence you handed Praxen didn't <em>show</em> a control that's actually in place (a review process, a deployment-time limit, an external guardrail, a monitoring pipeline, a red-team cadence). See <em>Results tuning</em> above for the additive-evidence workflow.</p>
+<p>The most common operator surprise — <em>"my agent is more careful than this report suggests."</em> In nearly every case, the evidence you handed Praxen didn't <em>show</em> a control that's actually in place. See <a href="#results-tuning">Results tuning</a> above for the additive-evidence workflow.</p>
 <h2 id="next-steps">Next steps</h2>
 <ul>
 <li><a href="writing-remits.html">Writing Worker Remits</a> — the authoring guide for the policy document</li>


### PR DESCRIPTION
## What

Adds the **OpenAI Codex plugin-marketplace** install path and, off the back of a close read, restructures the install/usage docs to be **agent-neutral** where they should be.

Prompted by #122 — investigating that "benign colon warning" led us to actually learn Codex's plugin/marketplace model. Headline finding: **Codex 0.142 has a real plugin marketplace, and our existing repo installs through it unchanged** (Codex reads `.claude-plugin/marketplace.json`; the skill surfaces to the model as `praxen:behavior-verifier`). Verified end-to-end against the live repo with `codex-cli 0.142.0-alpha.1`.

## Changes

**installation.md**
- Audience-based sections (**Claude Code** / **OpenAI Codex** / **Any other agent**) replacing Option A/B/C.
- Codex = two-command marketplace install (`marketplace add` + `plugin add`), parallel to Claude.
- "Any other agent" = plain-English *"clone the repo and use the `behavior-verifier` skill"* — no `curl`/`unzip`/`ln -sfn`.
- Dropped the standalone "Verifying" section (inline `# confirm:` does it), the Codex "gotcha" notes, and the empirically-false "already installed" caveat (`codex plugin add` upgrades cleanly — tested).
- Version floors aligned to `v1.0.0+`; Python prerequisite tightened.

**usage.md**
- "Running an analysis" is agent-neutral — one plain-English instruction for any agent; Codex CLI/sandbox mechanics removed.
- Internal step numbers (Step 4 / Step 9.9 / chunked-emission) replaced with behavioral descriptions.
- Dropped the "deterministic outputs" overclaim (contradicted the run-to-run-variability message).
- Context-compaction reframed from "silent failure" → detectable-and-recoverable (it contradicted our own draft-manifest / stdout-overview defenses).
- "Results tuning" tightened and cross-linked with challenging-findings Path 1 to remove duplicated explanation.

**challenging-findings.md / README.md / quickstart.md** — Path 1 links up to `usage.md#results-tuning`; dropped the stale Codex "skill link" path; headline Codex install is the one-command marketplace form.

## Verification
- Live Codex install/upgrade/uninstall + `debug prompt-input` (model-visible id) all exercised on `codex-cli 0.142.0-alpha.1`.
- Regenerated `guide/*.html`. CI render/manifest tests green (333 / 29 / 17).
- Merged current `dev` (incl. #131 scan-time, #130 plugin-smoke); no conflicts.

Closes #102 (Codex marketplace install verified shipping). Related: #122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)