### PR TITLE
chore: post-promotion follow-ups (CONTRIBUTING Codex block + smoke-script v-prefix)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,9 +174,10 @@ a tag.
    - **Codex (always manual):** the script drives only the `claude` CLI, so
      confirm the Codex marketplace leg by hand — in a scratch config,
      `codex plugin marketplace add open-agent-ai-security/praxen && codex plugin add praxen@open-agent-ai-security && codex plugin list`
-     (expect the new version; use `codex plugin marketplace upgrade …` for the
-     upgrade leg). The bundled skill surfaces to the model as
-     `praxen:behavior-verifier`.
+     (expect the new version). For the upgrade leg, refresh the snapshot then
+     re-install:
+     `codex plugin marketplace upgrade open-agent-ai-security && codex plugin add praxen@open-agent-ai-security`.
+     The bundled skill surfaces to the model as `praxen:behavior-verifier`.
 
 **Rolling back a bad release**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,11 +171,12 @@ a tag.
      `claude plugin marketplace add open-agent-ai-security/praxen && claude plugin install praxen@open-agent-ai-security && claude plugin list`
      (expect the new version, enabled); for the upgrade leg, install the prior
      tag first, then `claude plugin marketplace update … && claude plugin update …`.
-   - **Codex (always manual):** the script covers only the Claude Code
-     marketplace. Separately confirm the Codex skill-folder path surfaces the new
-     version — re-link / `git pull` (or re-unzip) and check `praxen:behavior-verifier`
-     resolves at `v<version>`. (Codex installs via a symlinked skill folder, not a
-     marketplace, so there is nothing for the script to drive.)
+   - **Codex (always manual):** the script drives only the `claude` CLI, so
+     confirm the Codex marketplace leg by hand — in a scratch config,
+     `codex plugin marketplace add open-agent-ai-security/praxen && codex plugin add praxen@open-agent-ai-security && codex plugin list`
+     (expect the new version; use `codex plugin marketplace upgrade …` for the
+     upgrade leg). The bundled skill surfaces to the model as
+     `praxen:behavior-verifier`.
 
 **Rolling back a bad release**
 

--- a/scripts/release/plugin-smoke.sh
+++ b/scripts/release/plugin-smoke.sh
@@ -68,6 +68,7 @@ trap cleanup EXIT
 installed_version() { claude plugin list 2>/dev/null | awk '/praxen@/{f=1} f&&/Version:/{print $2; exit}'; }
 assert_version() {
   local want="$1" got; got="$(installed_version)"
+  got="${got#v}"                       # normalize a possible 'v' prefix (want is already bare)
   [ "$got" = "$want" ] || fail "expected version '$want', got '${got:-<none>}'"
   echo "  ✓ reports $got"
 }


### PR DESCRIPTION
Two fix-forward items from the **#138 code reviews** (background review agent + Gemini), as agreed. Non-docs / contributor-tooling only — no engine/spec/manifest/CI/test changes. (#137's spec/skill GA metadata is deliberately **not** here — it's nearer the load-bearing surface and gets its own pass.)

1. **`CONTRIBUTING.md` — Codex release-check block** *(background agent)*. The "Codex (always manual)" step still described the pre-#134 model ("Codex installs via a symlinked skill folder, not a marketplace"), which contradicted the marketplace install #134 introduced in README/installation.md. Rewritten to the marketplace commands (`codex plugin marketplace add` / `codex plugin add` / `marketplace upgrade`); kept the accurate point that the smoke **script** drives only the `claude` CLI so the Codex leg stays a manual check.

2. **`scripts/release/plugin-smoke.sh:73` — `assert_version` hardening** *(Gemini)*. Strip a possible `v` prefix from the parsed version (`got="${got#v}"`) so a `v1.0.0`-vs-`1.0.0` CLI output can't false-fail. `want` is already normalized (lines 46/91), so stripping `got` is the complete fix.

`bash -n` passes. Closes the two items tracked in #138.