### PR TITLE
chore: switch project contact email to developer@exabeam.com (#140)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,7 +11,7 @@ This applies to every project space — issues, pull requests, code reviews, dis
 
 ## Reporting
 
-If you experience or witness conduct that you believe violates the Contributor Covenant, please report it privately to the project maintainers at **open-agent-ai-security@exabeam.com**. Include enough context for the maintainers to understand what happened, when, where, and who was involved. Reports are read and handled by the project maintainers and treated as confidential.
+If you experience or witness conduct that you believe violates the Contributor Covenant, please report it privately to the project maintainers at **developer@exabeam.com**. Include enough context for the maintainers to understand what happened, when, where, and who was involved. Reports are read and handled by the project maintainers and treated as confidential.
 
 You may also use GitHub's standard reporting tools (block, report content) for in-product behaviour; the maintainer email is the channel for cases that need a substantive maintainer response.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,7 @@ Use GitHub's private security advisory:
 
 GitHub will create a private advisory thread between you and the project maintainers. We will respond there.
 
-If GitHub Security Advisories are unavailable to you for any reason, email **open-agent-ai-security@exabeam.com** with the subject line **`Praxen security report`** and the same level of detail.
+If GitHub Security Advisories are unavailable to you for any reason, email **developer@exabeam.com** with the subject line **`Praxen security report`** and the same level of detail.
 
 ## What to expect
 


### PR DESCRIPTION
Implements **#140** — standardize the project contact on `developer@exabeam.com`, matching observra and the rest of the `open-agent-ai-security` family.

**Scope (governance docs only — no skill/spec/code):**
- `SECURITY.md:36` — vulnerability-disclosure **fallback** address
- `CODE_OF_CONDUCT.md:14` — Code of Conduct reporting address

`open-agent-ai-security@exabeam.com` → `developer@exabeam.com`. Verified **zero** remaining references to the old address in the repo.

### ⚠️ Merge gate (from the RFE's acceptance criteria)
`SECURITY.md` is the security-disclosure channel, so before merge: **confirm `developer@exabeam.com` is a monitored inbox** for inbound security reports (or that GitHub Security Advisories stays the primary path). That's the one item I can't verify — needs maintainer sign-off.

Closes #140 once the inbox is confirmed.