### PR TITLE
Promote dev → main: contact-email + post-promotion follow-ups

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,7 +11,7 @@ This applies to every project space — issues, pull requests, code reviews, dis
 
 ## Reporting
 
-If you experience or witness conduct that you believe violates the Contributor Covenant, please report it privately to the project maintainers at **open-agent-ai-security@exabeam.com**. Include enough context for the maintainers to understand what happened, when, where, and who was involved. Reports are read and handled by the project maintainers and treated as confidential.
+If you experience or witness conduct that you believe violates the Contributor Covenant, please report it privately to the project maintainers at **developer@exabeam.com**. Include enough context for the maintainers to understand what happened, when, where, and who was involved. Reports are read and handled by the project maintainers and treated as confidential.
 
 You may also use GitHub's standard reporting tools (block, report content) for in-product behaviour; the maintainer email is the channel for cases that need a substantive maintainer response.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,11 +171,13 @@ a tag.
      `claude plugin marketplace add open-agent-ai-security/praxen && claude plugin install praxen@open-agent-ai-security && claude plugin list`
      (expect the new version, enabled); for the upgrade leg, install the prior
      tag first, then `claude plugin marketplace update … && claude plugin update …`.
-   - **Codex (always manual):** the script covers only the Claude Code
-     marketplace. Separately confirm the Codex skill-folder path surfaces the new
-     version — re-link / `git pull` (or re-unzip) and check `praxen:behavior-verifier`
-     resolves at `v<version>`. (Codex installs via a symlinked skill folder, not a
-     marketplace, so there is nothing for the script to drive.)
+   - **Codex (always manual):** the script drives only the `claude` CLI, so
+     confirm the Codex marketplace leg by hand — in a scratch config,
+     `codex plugin marketplace add open-agent-ai-security/praxen && codex plugin add praxen@open-agent-ai-security && codex plugin list`
+     (expect the new version). For the upgrade leg, refresh the snapshot then
+     re-install:
+     `codex plugin marketplace upgrade open-agent-ai-security && codex plugin add praxen@open-agent-ai-security`.
+     The bundled skill surfaces to the model as `praxen:behavior-verifier`.
 
 **Rolling back a bad release**
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,7 @@ Use GitHub's private security advisory:
 
 GitHub will create a private advisory thread between you and the project maintainers. We will respond there.
 
-If GitHub Security Advisories are unavailable to you for any reason, email **open-agent-ai-security@exabeam.com** with the subject line **`Praxen security report`** and the same level of detail.
+If GitHub Security Advisories are unavailable to you for any reason, email **developer@exabeam.com** with the subject line **`Praxen security report`** and the same level of detail.
 
 ## What to expect
 

--- a/scripts/release/plugin-smoke.sh
+++ b/scripts/release/plugin-smoke.sh
@@ -68,6 +68,7 @@ trap cleanup EXIT
 installed_version() { claude plugin list 2>/dev/null | awk '/praxen@/{f=1} f&&/Version:/{print $2; exit}'; }
 assert_version() {
   local want="$1" got; got="$(installed_version)"
+  got="${got#v}"                       # normalize a possible 'v' prefix (want is already bare)
   [ "$got" = "$want" ] || fail "expected version '$want', got '${got:-<none>}'"
   echo "  ✓ reports $got"
 }


### PR DESCRIPTION
Small promotion of two already-merged, already-reviewed fixes.

- **#142** — switch project contact to `developer@exabeam.com` (SECURITY.md + CODE_OF_CONDUCT.md); closes #140
- **#139** — CONTRIBUTING Codex release-check block corrected to the marketplace model + `plugin-smoke.sh` `v`-prefix hardening (from the #138 review)

**Audit:** governance docs (SECURITY.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md) + the unshipped release script. No skill/spec/manifest/CI/test changes.