### PR TITLE
site: halve the hero→news-ticker vertical gap

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
     .menu-toggle { display: none; }
 
     /* ---------- Hero ---------- */
-    .hero { position: relative; padding: 36px 0 70px; }
+    .hero { position: relative; padding: 36px 0 35px; }
     .hero::before {
       content: ""; position: absolute; inset: 0; z-index: -2;
       background:
@@ -293,7 +293,7 @@
       body { font-size: 16px; }
       .pillars { grid-template-columns: 1fr; }
       .nav-cta .btn-ghost { display: none; }
-      .hero { padding: 28px 0 50px; }
+      .hero { padding: 28px 0 25px; }
       .section-pad { padding: 56px 0; }
     }
   </style>


### PR DESCRIPTION
Tighten the vertical space between the hero Get-started CTA and the news ticker — hero bottom padding 70→35px (desktop), 50→25px (mobile). CSS-only, no version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)