### PR TITLE
news: add Help Net Security "hottest open-source tools of June 2026" roundup

### DIFF
--- a/news.html
+++ b/news.html
@@ -161,7 +161,7 @@
         </p>
         <div class="topline">
           <div class="stat"><strong>20+</strong><span>placements</span></div>
-          <div class="stat"><strong>10</strong><span>editorial features</span></div>
+          <div class="stat"><strong>11</strong><span>editorial features</span></div>
           <div class="stat"><strong>June 2026</strong><span>launch window</span></div>
         </div>
       </div>
@@ -232,6 +232,11 @@
           <a class="cov-card" href="https://www.itnewsafrica.com/2026/06/exabeam-launches-open-source-praxen-for-ai-agent-verification/" target="_blank" rel="noopener">
             <div class="cov-outlet">IT News Africa</div>
             <p class="cov-title">Exabeam launches open-source Praxen for AI agent verification</p>
+            <span class="cov-read">Read →</span>
+          </a>
+          <a class="cov-card" href="https://www.helpnetsecurity.com/2026/06/30/hottest-cybersecurity-open-source-tools-of-the-month-june-2026/" target="_blank" rel="noopener">
+            <div class="cov-outlet">Help Net Security</div>
+            <p class="cov-title">Praxen featured among the hottest open-source cybersecurity tools of June 2026</p>
             <span class="cov-read">Read →</span>
           </a>
         </div>


### PR DESCRIPTION
Adds the **June 30 Help Net Security** monthly roundup — *"Hottest cybersecurity open-source tools of the month: June 2026"* — where Praxen is named among the month's hottest open-source tools (*"an open-source tool with a simple job: it checks whether an AI agent does what it claims to do"*). A nice post-launch / staying-power signal from a top-tier outlet.

## Scope
- **news.html only.** New Editorial coverage card (Help Net Security · roundup) + editorial topline ticked **10 → 11** to match the card count.
- **Launch stats reports are frozen and untouched** (`stats/` not modified) — this is ongoing press, not a launch-retrospective change.

## Checks
- Editorial `.cov-grid` = 11 cards ↔ topline "11 editorial features"; tags balanced; new link has `target="_blank" rel="noopener"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)