### PR TITLE
Promote dev → main: community news mentions (Satoshi, elponick, Wilson)

### DIFF
--- a/news.html
+++ b/news.html
@@ -268,9 +268,24 @@
             <p class="cov-title">Behavioral Verification Is Not Optional for AI Agents in Regulated Industries</p>
             <span class="cov-read">Read →</span>
           </a>
+          <a class="cov-card" href="https://www.linkedin.com/pulse/scanner-soc-agent-prompt-lied-steve-wilson-j3zvc/" target="_blank" rel="noopener">
+            <div class="cov-outlet">Steve Wilson · LinkedIn</div>
+            <p class="cov-title">The Scanner, the SOC Agent, and the Prompt That Lied — a Praxen maturity scan (1.85 → 2.75) shows why deterministic guardrails beat prompt-only enforcement</p>
+            <span class="cov-read">Read →</span>
+          </a>
           <a class="cov-card" href="https://x.com/kameki23/status/2071066154697974018" target="_blank" rel="noopener">
             <div class="cov-outlet">Kameda Naoki (@kameki23) · X</div>
             <p class="cov-title">AI agent behavior verification, achieved in open source — this could change the future of AI (Japanese-language thread)</p>
+            <span class="cov-read">Read →</span>
+          </a>
+          <a class="cov-card" href="https://x.com/__SatoshiSsSs__/status/2074369333153902836" target="_blank" rel="noopener">
+            <div class="cov-outlet">Sekioka Satoshi (@__SatoshiSsSs__) · X</div>
+            <p class="cov-title">Running agents without behavior observation is a gamble — a Verify-Observe-Analyze-Improve playbook built on Praxen remit verification and Observra telemetry standardization (Japanese-language thread)</p>
+            <span class="cov-read">Read →</span>
+          </a>
+          <a class="cov-card" href="https://x.com/elponick/status/2070752275874587035" target="_blank" rel="noopener">
+            <div class="cov-outlet">@elponick · X</div>
+            <p class="cov-title">Exabeam launched Praxen — agent verification as a Claude Code plugin, built by the OWASP Gen AI Security chair: checks permissions, boundaries, and controls pre-deployment, every release</p>
             <span class="cov-read">Read →</span>
           </a>
           <div class="cov-card" style="transform:none;border-color:var(--border);background:var(--panel);cursor:default">


### PR DESCRIPTION
Promotes the merged community-news additions from `dev` to `main` (the release branch the live news page + marketplace serve).

Contents (already reviewed & merged to `dev` in #152): three new "Industry commentary" cards on `news.html` — Sekioka Satoshi (X), @elponick (X), and Steve Wilson (LinkedIn, "The Scanner, the SOC Agent, and the Prompt That Lied").

News-only change — no plugin/version bump. Merge as a **merge commit** (not squash), per the dev→main promotion model in `branch-drift.yml`; `dev` will be fast-forwarded back to `main` afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
