### PR TITLE
news: 3 editorial cards (SevenLab, News4Hackers, Help Net July) + topline counts

### DIFF
--- a/news.html
+++ b/news.html
@@ -239,6 +239,16 @@
             <p class="cov-title">Praxen featured among the hottest open-source cybersecurity tools of June 2026</p>
             <span class="cov-read">Read →</span>
           </a>
+          <a class="cov-card" href="https://www.sevenlab.ai/ai-news/exabeam-releases-open-source-praxen-to-verify-ai-agent-behaviour-and-security" target="_blank" rel="noopener">
+            <div class="cov-outlet">SevenLab</div>
+            <p class="cov-title">Exabeam releases open-source Praxen to verify AI agent behaviour and security</p>
+            <span class="cov-read">Read →</span>
+          </a>
+          <a class="cov-card" href="https://www.news4hackers.com/praxen-open-source-ai-agent-behavior-verification/" target="_blank" rel="noopener">
+            <div class="cov-outlet">News4Hackers</div>
+            <p class="cov-title">Praxen: Open-Source AI Agent Behavior Verification</p>
+            <span class="cov-read">Read →</span>
+          </a>
         </div>
       </div>
     </section>

--- a/news.html
+++ b/news.html
@@ -160,8 +160,8 @@
           cybersecurity, AI, and enterprise-technology media. A selection below.
         </p>
         <div class="topline">
-          <div class="stat"><strong>20+</strong><span>placements</span></div>
-          <div class="stat"><strong>11</strong><span>editorial features</span></div>
+          <div class="stat"><strong>35+</strong><span>placements</span></div>
+          <div class="stat"><strong>14</strong><span>editorial features</span></div>
           <div class="stat"><strong>June 2026</strong><span>launch window</span></div>
         </div>
       </div>
@@ -247,6 +247,11 @@
           <a class="cov-card" href="https://www.news4hackers.com/praxen-open-source-ai-agent-behavior-verification/" target="_blank" rel="noopener">
             <div class="cov-outlet">News4Hackers</div>
             <p class="cov-title">Praxen: Open-Source AI Agent Behavior Verification</p>
+            <span class="cov-read">Read →</span>
+          </a>
+          <a class="cov-card" href="https://www.helpnetsecurity.com/2026/07/08/20-latest-open-source-cybersecurity-tools/" target="_blank" rel="noopener">
+            <div class="cov-outlet">Help Net Security</div>
+            <p class="cov-title">Praxen featured among 20 open-source cybersecurity tools to keep your team ready</p>
             <span class="cov-read">Read →</span>
           </a>
         </div>


### PR DESCRIPTION
Three new cards in the **Editorial coverage** section of `news.html`, all covering the Praxen open-source launch:

- **SevenLab** — "Exabeam releases open-source Praxen to verify AI agent behaviour and security"
- **News4Hackers** — "Praxen: Open-Source AI Agent Behavior Verification"
- **Help Net Security** — "Praxen featured among 20 open-source cybersecurity tools…" (July 2026 roundup)

Also corrects the hero **topline counts** to match current coverage: editorial features **11 → 14**, placements **20+ → 35+** (actual total ~39 across editorial + commentary + syndications + announcement).

Targets `dev` per the branching model. News-only; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
