### PR TITLE
Promote dev → main: SevenLab + News4Hackers + Help Net July editorial cards

### DIFF
--- a/news.html
+++ b/news.html
@@ -160,8 +160,8 @@
           cybersecurity, AI, and enterprise-technology media. A selection below.
         </p>
         <div class="topline">
-          <div class="stat"><strong>20+</strong><span>placements</span></div>
-          <div class="stat"><strong>11</strong><span>editorial features</span></div>
+          <div class="stat"><strong>35+</strong><span>placements</span></div>
+          <div class="stat"><strong>14</strong><span>editorial features</span></div>
           <div class="stat"><strong>June 2026</strong><span>launch window</span></div>
         </div>
       </div>
@@ -237,6 +237,21 @@
           <a class="cov-card" href="https://www.helpnetsecurity.com/2026/06/30/hottest-cybersecurity-open-source-tools-of-the-month-june-2026/" target="_blank" rel="noopener">
             <div class="cov-outlet">Help Net Security</div>
             <p class="cov-title">Praxen featured among the hottest open-source cybersecurity tools of June 2026</p>
+            <span class="cov-read">Read →</span>
+          </a>
+          <a class="cov-card" href="https://www.sevenlab.ai/ai-news/exabeam-releases-open-source-praxen-to-verify-ai-agent-behaviour-and-security" target="_blank" rel="noopener">
+            <div class="cov-outlet">SevenLab</div>
+            <p class="cov-title">Exabeam releases open-source Praxen to verify AI agent behaviour and security</p>
+            <span class="cov-read">Read →</span>
+          </a>
+          <a class="cov-card" href="https://www.news4hackers.com/praxen-open-source-ai-agent-behavior-verification/" target="_blank" rel="noopener">
+            <div class="cov-outlet">News4Hackers</div>
+            <p class="cov-title">Praxen: Open-Source AI Agent Behavior Verification</p>
+            <span class="cov-read">Read →</span>
+          </a>
+          <a class="cov-card" href="https://www.helpnetsecurity.com/2026/07/08/20-latest-open-source-cybersecurity-tools/" target="_blank" rel="noopener">
+            <div class="cov-outlet">Help Net Security</div>
+            <p class="cov-title">Praxen featured among 20 open-source cybersecurity tools to keep your team ready</p>
             <span class="cov-read">Read →</span>
           </a>
         </div>


### PR DESCRIPTION
Promotes the #154 editorial-coverage additions (SevenLab, News4Hackers, Help Net July roundup) + topline count fix (editorial 11→14, placements 20+→35+) from `dev` to `main` so they go live. News-only; merge-commit + FF dev per the promotion model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)