### PR TITLE
docs: surface "not a gate" + "not a sandbox" as design choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ Each finding is tagged against the **OWASP Top 10 for LLM Applications 2025**, *
 
 ---
 
+## What Praxen is (and isn't)
+
+Praxen is **decision support, not an enforcement gate.** Its findings and RAISE maturity score are model-assisted expert judgments meant to focus a human reviewer — not a deterministic pass/fail signal. Scores vary run to run and are calibrated per model tier ([details](docs/understanding-variability.md)), so read a report as an expert review to act on, not a rubber stamp to automate against — and when you disagree with a finding, [challenge and revise it](docs/challenging-findings.md).
+
+Praxen is **read-only by design — but by convention, not by a sandbox.** It reads your agent's real workspace (code, config, logs) and writes only to `./reports/`, never modifying the agent. But it runs inside your coding agent with that agent's ordinary tool access (Bash, Write), so the read-only posture is a behavioral contract, not an isolation boundary — the same declared-versus-enforced distinction Praxen flags when it scans other agents. Run it where you'd already trust that agent to operate; see [Security model and assumptions](SECURITY.md#security-model-and-assumptions).
+
+---
+
 ## Get started
 
 - [**Installation**](docs/installation.md) — Claude Code or OpenAI Codex (plugin marketplace), or any other agent (point it at the repo)

--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ Each finding is tagged against the **OWASP Top 10 for LLM Applications 2025**, *
 
 ---
 
-## What Praxen is (and isn't)
+## Working with Praxen
 
-Praxen is **decision support, not an enforcement gate.** Its findings and RAISE maturity score are model-assisted expert judgments meant to focus a human reviewer — not a deterministic pass/fail signal. Scores vary run to run and are calibrated per model tier ([details](docs/understanding-variability.md)), so read a report as an expert review to act on, not a rubber stamp to automate against — and when you disagree with a finding, [challenge and revise it](docs/challenging-findings.md).
+Praxen produces an **expert review that focuses human attention.** Each report is a model-assisted analysis of where an agent's behavior may diverge from its remit. Treat the findings and RAISE maturity score as judgments to act on — a senior reviewer's notes, not an automated pass/fail. Scores are calibrated per model tier and vary run to run ([details](docs/understanding-variability.md)), and you can [challenge and revise any finding](docs/challenging-findings.md).
 
-Praxen is **read-only by design — but by convention, not by a sandbox.** It reads your agent's real workspace (code, config, logs) and writes only to `./reports/`, never modifying the agent. But it runs inside your coding agent with that agent's ordinary tool access (Bash, Write), so the read-only posture is a behavioral contract, not an isolation boundary — the same declared-versus-enforced distinction Praxen flags when it scans other agents. Run it where you'd already trust that agent to operate; see [Security model and assumptions](SECURITY.md#security-model-and-assumptions).
+Praxen works by **reading your agent's real workspace in place** — its actual code, config, and logs. It writes findings only to `./reports/` and never modifies the agent. It runs as a skill inside your coding agent, using that agent's own tools rather than a separate sandbox, so run Praxen where you already trust that agent to operate. The [security model and assumptions](SECURITY.md#security-model-and-assumptions) covers this in full.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Praxen runs as a skill *inside* your coding agent (Claude Code, OpenAI Codex, or
 - **Read-only by convention, not by isolation.** Praxen is designed to operate read-only on the agent's workspace: it reads artifacts (code, config, logs, governance docs) and writes output only to its own `./reports/` directory. It does not act on the agent's behalf and does not modify the agent's code, skill files, configuration, or dependencies. But this is a **behavioral contract of the skill's instructions, not a technical sandbox** — Praxen runs with the coding agent's ordinary tool access (including Bash and Write), so the read-only posture is enforced by convention rather than by an isolation boundary. (This is the same declared-versus-enforced distinction Praxen itself flags when it scans other agents.) Run Praxen only where you already trust the coding agent to operate.
 - **Local by default.** Reports are written locally to `./reports/` (HTML, JSON, text). Nothing phones home.
 
-For how to read Praxen's *output* — findings are model-assisted expert review, not a deterministic gate — see [What Praxen is (and isn't)](README.md#what-praxen-is-and-isnt).
+For guidance on interpreting Praxen's *output* — a model-assisted expert review rather than a deterministic gate — see [Working with Praxen](README.md#working-with-praxen).
 
 ## Scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,6 +7,15 @@
 
 Praxen is a security tool. We take vulnerabilities in Praxen itself seriously. This document describes how to report one privately, what is in scope, and what to expect after you report.
 
+## Security model and assumptions
+
+Praxen runs as a skill *inside* your coding agent (Claude Code, OpenAI Codex, or similar) — not as a standalone, sandboxed service. Two properties are worth stating plainly before you run it:
+
+- **Read-only by convention, not by isolation.** Praxen is designed to operate read-only on the agent's workspace: it reads artifacts (code, config, logs, governance docs) and writes output only to its own `./reports/` directory. It does not act on the agent's behalf and does not modify the agent's code, skill files, configuration, or dependencies. But this is a **behavioral contract of the skill's instructions, not a technical sandbox** — Praxen runs with the coding agent's ordinary tool access (including Bash and Write), so the read-only posture is enforced by convention rather than by an isolation boundary. (This is the same declared-versus-enforced distinction Praxen itself flags when it scans other agents.) Run Praxen only where you already trust the coding agent to operate.
+- **Local by default.** Reports are written locally to `./reports/` (HTML, JSON, text). Nothing phones home.
+
+For how to read Praxen's *output* — findings are model-assisted expert review, not a deterministic gate — see [What Praxen is (and isn't)](README.md#what-praxen-is-and-isnt).
+
 ## Scope
 
 **In scope** — vulnerabilities in Praxen itself:

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@
 | Looking at a report and trying to understand it | [Interpreting Reports](interpreting-reports.md) |
 | Disagreeing with a finding or wanting to revise it | [Challenging and Revising Findings](challenging-findings.md) |
 | Wondering why two runs gave slightly different scores | [Understanding Run-to-Run Variability](understanding-variability.md) |
+| Wondering whether Praxen is a pass/fail gate or a sandbox | [What Praxen is (and isn't)](#what-praxen-is-and-isnt) |
 | Hit a problem on a first run | [Usage § Troubleshooting](usage.md#troubleshooting) |
 | Trying to understand the OWASP frameworks Praxen tags against | [OWASP Gen AI Security](owasp.md) |
 | Trying to understand the RAISE maturity scoring | [The RAISE Framework](RAISE.md) |
@@ -46,6 +47,12 @@ flowchart LR
 ```
 
 The output is a self-contained HTML analysis report, a machine-readable findings JSON, and a plain-text summary. Open the HTML in a browser; ingest the JSON in your pipeline.
+
+## What Praxen is (and isn't)
+
+Praxen is **decision support, not an enforcement gate.** Findings and the RAISE maturity score are model-assisted expert judgments meant to focus a human reviewer — not a deterministic pass/fail signal. Scores vary run to run and are calibrated per model tier, so read a report as an expert review to act on, not a rubber stamp to automate against. See [Understanding Run-to-Run Variability](understanding-variability.md), and [Challenging and Revising Findings](challenging-findings.md) when you disagree with a finding.
+
+Praxen is **read-only by design — but by convention, not by a sandbox.** It reads your agent's real workspace (code, config, logs) and writes only to `./reports/`, never modifying the agent. But it runs inside your coding agent with that agent's ordinary tool access (Bash, Write), so the read-only posture is a behavioral contract, not an isolation boundary — the same declared-versus-enforced distinction Praxen flags when it scans other agents. Run it where you'd already trust that agent to operate; see [Security model and assumptions](../SECURITY.md#security-model-and-assumptions).
 
 ## Four input shapes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@
 | Looking at a report and trying to understand it | [Interpreting Reports](interpreting-reports.md) |
 | Disagreeing with a finding or wanting to revise it | [Challenging and Revising Findings](challenging-findings.md) |
 | Wondering why two runs gave slightly different scores | [Understanding Run-to-Run Variability](understanding-variability.md) |
-| Wondering whether Praxen is a pass/fail gate or a sandbox | [What Praxen is (and isn't)](#what-praxen-is-and-isnt) |
+| Getting the most out of a Praxen report | [Working with Praxen](#working-with-praxen) |
 | Hit a problem on a first run | [Usage § Troubleshooting](usage.md#troubleshooting) |
 | Trying to understand the OWASP frameworks Praxen tags against | [OWASP Gen AI Security](owasp.md) |
 | Trying to understand the RAISE maturity scoring | [The RAISE Framework](RAISE.md) |
@@ -48,11 +48,11 @@ flowchart LR
 
 The output is a self-contained HTML analysis report, a machine-readable findings JSON, and a plain-text summary. Open the HTML in a browser; ingest the JSON in your pipeline.
 
-## What Praxen is (and isn't)
+## Working with Praxen
 
-Praxen is **decision support, not an enforcement gate.** Findings and the RAISE maturity score are model-assisted expert judgments meant to focus a human reviewer — not a deterministic pass/fail signal. Scores vary run to run and are calibrated per model tier, so read a report as an expert review to act on, not a rubber stamp to automate against. See [Understanding Run-to-Run Variability](understanding-variability.md), and [Challenging and Revising Findings](challenging-findings.md) when you disagree with a finding.
+Praxen produces an **expert review that focuses human attention.** Each report is a model-assisted analysis of where an agent's behavior may diverge from its remit. Treat the findings and RAISE maturity score as judgments to act on — a senior reviewer's notes, not an automated pass/fail. Scores are calibrated per model tier and vary run to run (see [Understanding Run-to-Run Variability](understanding-variability.md)), and you can [challenge and revise any finding](challenging-findings.md).
 
-Praxen is **read-only by design — but by convention, not by a sandbox.** It reads your agent's real workspace (code, config, logs) and writes only to `./reports/`, never modifying the agent. But it runs inside your coding agent with that agent's ordinary tool access (Bash, Write), so the read-only posture is a behavioral contract, not an isolation boundary — the same declared-versus-enforced distinction Praxen flags when it scans other agents. Run it where you'd already trust that agent to operate; see [Security model and assumptions](../SECURITY.md#security-model-and-assumptions).
+Praxen works by **reading your agent's real workspace in place** — its actual code, config, and logs. It writes findings only to `./reports/` and never modifies the agent. It runs as a skill inside your coding agent, using that agent's own tools rather than a separate sandbox, so run Praxen where you already trust that agent to operate. The [security model and assumptions](../SECURITY.md#security-model-and-assumptions) covers this in full.
 
 ## Four input shapes
 

--- a/guide/index.html
+++ b/guide/index.html
@@ -243,7 +243,7 @@ img { max-width: 100%; display: block; }
   </div>
 </header>
 <div class="docs-shell">
-  <aside class="docs-sidebar"><nav class="docs-nav"><div class="docs-nav-title">Documentation</div><ul><li><a href="index.html" class="active">Overview</a><ul class="docs-subnav"><li><a href="#where-to-start">Where to start</a></li><li><a href="#how-praxen-works-in-90-seconds">How Praxen works (in 90 seconds)</a></li><li><a href="#what-praxen-is-and-isnt">What Praxen is (and isn&#x27;t)</a></li><li><a href="#four-input-shapes">Four input shapes</a></li><li><a href="#frameworks">Frameworks</a></li><li><a href="#quick-reference">Quick reference</a></li></ul></li><li><a href="installation.html">Installation</a></li><li><a href="quickstart.html">Quickstart</a></li><li><a href="usage.html">Usage</a></li><li><a href="writing-remits.html">Writing Worker Remits</a></li><li><a href="interpreting-reports.html">Interpreting Reports</a></li><li><a href="challenging-findings.html">Challenging Findings</a></li><li><a href="understanding-variability.html">Run-to-Run Variability</a></li><li><a href="abv.html">Agent Behavior Verification</a></li><li><a href="owasp.html">OWASP Gen AI Security</a></li><li><a href="RAISE.html">The RAISE Framework</a></li></ul></nav></aside>
+  <aside class="docs-sidebar"><nav class="docs-nav"><div class="docs-nav-title">Documentation</div><ul><li><a href="index.html" class="active">Overview</a><ul class="docs-subnav"><li><a href="#where-to-start">Where to start</a></li><li><a href="#how-praxen-works-in-90-seconds">How Praxen works (in 90 seconds)</a></li><li><a href="#working-with-praxen">Working with Praxen</a></li><li><a href="#four-input-shapes">Four input shapes</a></li><li><a href="#frameworks">Frameworks</a></li><li><a href="#quick-reference">Quick reference</a></li></ul></li><li><a href="installation.html">Installation</a></li><li><a href="quickstart.html">Quickstart</a></li><li><a href="usage.html">Usage</a></li><li><a href="writing-remits.html">Writing Worker Remits</a></li><li><a href="interpreting-reports.html">Interpreting Reports</a></li><li><a href="challenging-findings.html">Challenging Findings</a></li><li><a href="understanding-variability.html">Run-to-Run Variability</a></li><li><a href="abv.html">Agent Behavior Verification</a></li><li><a href="owasp.html">OWASP Gen AI Security</a></li><li><a href="RAISE.html">The RAISE Framework</a></li></ul></nav></aside>
   <main class="docs-main">
     <article class="prose"><h1 id="praxen-documentation">Praxen Documentation</h1>
 <p><strong>Praxen</strong> is the open-source reference implementation of <strong><a href="abv.html">Agent Behavior Verification (ABV)</a></strong> — a proactive control model for AI agents and digital workers. It compares an AI agent's declared policy (a Worker Remit) against whatever evidence is available about that agent — source code, live deployment state, behavioral artifacts, governance docs, or any mix — and reports where observed behavior diverges from declared intent.</p>
@@ -293,8 +293,8 @@ img { max-width: 100%; display: block; }
 <td><a href="understanding-variability.html">Understanding Run-to-Run Variability</a></td>
 </tr>
 <tr>
-<td>Wondering whether Praxen is a pass/fail gate or a sandbox</td>
-<td><a href="#what-praxen-is-and-isnt">What Praxen is (and isn't)</a></td>
+<td>Getting the most out of a Praxen report</td>
+<td><a href="#working-with-praxen">Working with Praxen</a></td>
 </tr>
 <tr>
 <td>Hit a problem on a first run</td>
@@ -326,9 +326,9 @@ img { max-width: 100%; display: block; }
   R --> TXT["analysis.txt"]
 </pre>
 <p>The output is a self-contained HTML analysis report, a machine-readable findings JSON, and a plain-text summary. Open the HTML in a browser; ingest the JSON in your pipeline.</p>
-<h2 id="what-praxen-is-and-isnt">What Praxen is (and isn't)</h2>
-<p>Praxen is <strong>decision support, not an enforcement gate.</strong> Findings and the RAISE maturity score are model-assisted expert judgments meant to focus a human reviewer — not a deterministic pass/fail signal. Scores vary run to run and are calibrated per model tier, so read a report as an expert review to act on, not a rubber stamp to automate against. See <a href="understanding-variability.html">Understanding Run-to-Run Variability</a>, and <a href="challenging-findings.html">Challenging and Revising Findings</a> when you disagree with a finding.</p>
-<p>Praxen is <strong>read-only by design — but by convention, not by a sandbox.</strong> It reads your agent's real workspace (code, config, logs) and writes only to <code>./reports/</code>, never modifying the agent. But it runs inside your coding agent with that agent's ordinary tool access (Bash, Write), so the read-only posture is a behavioral contract, not an isolation boundary — the same declared-versus-enforced distinction Praxen flags when it scans other agents. Run it where you'd already trust that agent to operate; see <a href="https://github.com/open-agent-ai-security/praxen/blob/main/SECURITY.md#security-model-and-assumptions">Security model and assumptions</a>.</p>
+<h2 id="working-with-praxen">Working with Praxen</h2>
+<p>Praxen produces an <strong>expert review that focuses human attention.</strong> Each report is a model-assisted analysis of where an agent's behavior may diverge from its remit. Treat the findings and RAISE maturity score as judgments to act on — a senior reviewer's notes, not an automated pass/fail. Scores are calibrated per model tier and vary run to run (see <a href="understanding-variability.html">Understanding Run-to-Run Variability</a>), and you can <a href="challenging-findings.html">challenge and revise any finding</a>.</p>
+<p>Praxen works by <strong>reading your agent's real workspace in place</strong> — its actual code, config, and logs. It writes findings only to <code>./reports/</code> and never modifies the agent. It runs as a skill inside your coding agent, using that agent's own tools rather than a separate sandbox, so run Praxen where you already trust that agent to operate. The <a href="https://github.com/open-agent-ai-security/praxen/blob/main/SECURITY.md#security-model-and-assumptions">security model and assumptions</a> covers this in full.</p>
 <h2 id="four-input-shapes">Four input shapes</h2>
 <p>Praxen is <strong>not just a source-code analyzer.</strong> Any of these — alone or in combination — are valid input:</p>
 <ul>

--- a/guide/index.html
+++ b/guide/index.html
@@ -243,7 +243,7 @@ img { max-width: 100%; display: block; }
   </div>
 </header>
 <div class="docs-shell">
-  <aside class="docs-sidebar"><nav class="docs-nav"><div class="docs-nav-title">Documentation</div><ul><li><a href="index.html" class="active">Overview</a><ul class="docs-subnav"><li><a href="#where-to-start">Where to start</a></li><li><a href="#how-praxen-works-in-90-seconds">How Praxen works (in 90 seconds)</a></li><li><a href="#four-input-shapes">Four input shapes</a></li><li><a href="#frameworks">Frameworks</a></li><li><a href="#quick-reference">Quick reference</a></li></ul></li><li><a href="installation.html">Installation</a></li><li><a href="quickstart.html">Quickstart</a></li><li><a href="usage.html">Usage</a></li><li><a href="writing-remits.html">Writing Worker Remits</a></li><li><a href="interpreting-reports.html">Interpreting Reports</a></li><li><a href="challenging-findings.html">Challenging Findings</a></li><li><a href="understanding-variability.html">Run-to-Run Variability</a></li><li><a href="abv.html">Agent Behavior Verification</a></li><li><a href="owasp.html">OWASP Gen AI Security</a></li><li><a href="RAISE.html">The RAISE Framework</a></li></ul></nav></aside>
+  <aside class="docs-sidebar"><nav class="docs-nav"><div class="docs-nav-title">Documentation</div><ul><li><a href="index.html" class="active">Overview</a><ul class="docs-subnav"><li><a href="#where-to-start">Where to start</a></li><li><a href="#how-praxen-works-in-90-seconds">How Praxen works (in 90 seconds)</a></li><li><a href="#what-praxen-is-and-isnt">What Praxen is (and isn&#x27;t)</a></li><li><a href="#four-input-shapes">Four input shapes</a></li><li><a href="#frameworks">Frameworks</a></li><li><a href="#quick-reference">Quick reference</a></li></ul></li><li><a href="installation.html">Installation</a></li><li><a href="quickstart.html">Quickstart</a></li><li><a href="usage.html">Usage</a></li><li><a href="writing-remits.html">Writing Worker Remits</a></li><li><a href="interpreting-reports.html">Interpreting Reports</a></li><li><a href="challenging-findings.html">Challenging Findings</a></li><li><a href="understanding-variability.html">Run-to-Run Variability</a></li><li><a href="abv.html">Agent Behavior Verification</a></li><li><a href="owasp.html">OWASP Gen AI Security</a></li><li><a href="RAISE.html">The RAISE Framework</a></li></ul></nav></aside>
   <main class="docs-main">
     <article class="prose"><h1 id="praxen-documentation">Praxen Documentation</h1>
 <p><strong>Praxen</strong> is the open-source reference implementation of <strong><a href="abv.html">Agent Behavior Verification (ABV)</a></strong> — a proactive control model for AI agents and digital workers. It compares an AI agent's declared policy (a Worker Remit) against whatever evidence is available about that agent — source code, live deployment state, behavioral artifacts, governance docs, or any mix — and reports where observed behavior diverges from declared intent.</p>
@@ -293,6 +293,10 @@ img { max-width: 100%; display: block; }
 <td><a href="understanding-variability.html">Understanding Run-to-Run Variability</a></td>
 </tr>
 <tr>
+<td>Wondering whether Praxen is a pass/fail gate or a sandbox</td>
+<td><a href="#what-praxen-is-and-isnt">What Praxen is (and isn't)</a></td>
+</tr>
+<tr>
 <td>Hit a problem on a first run</td>
 <td><a href="usage.html#troubleshooting">Usage § Troubleshooting</a></td>
 </tr>
@@ -322,6 +326,9 @@ img { max-width: 100%; display: block; }
   R --> TXT["analysis.txt"]
 </pre>
 <p>The output is a self-contained HTML analysis report, a machine-readable findings JSON, and a plain-text summary. Open the HTML in a browser; ingest the JSON in your pipeline.</p>
+<h2 id="what-praxen-is-and-isnt">What Praxen is (and isn't)</h2>
+<p>Praxen is <strong>decision support, not an enforcement gate.</strong> Findings and the RAISE maturity score are model-assisted expert judgments meant to focus a human reviewer — not a deterministic pass/fail signal. Scores vary run to run and are calibrated per model tier, so read a report as an expert review to act on, not a rubber stamp to automate against. See <a href="understanding-variability.html">Understanding Run-to-Run Variability</a>, and <a href="challenging-findings.html">Challenging and Revising Findings</a> when you disagree with a finding.</p>
+<p>Praxen is <strong>read-only by design — but by convention, not by a sandbox.</strong> It reads your agent's real workspace (code, config, logs) and writes only to <code>./reports/</code>, never modifying the agent. But it runs inside your coding agent with that agent's ordinary tool access (Bash, Write), so the read-only posture is a behavioral contract, not an isolation boundary — the same declared-versus-enforced distinction Praxen flags when it scans other agents. Run it where you'd already trust that agent to operate; see <a href="https://github.com/open-agent-ai-security/praxen/blob/main/SECURITY.md#security-model-and-assumptions">Security model and assumptions</a>.</p>
 <h2 id="four-input-shapes">Four input shapes</h2>
 <p>Praxen is <strong>not just a source-code analyzer.</strong> Any of these — alone or in combination — are valid input:</p>
 <ul>


### PR DESCRIPTION
Turns the two positioning caveats from our July 2026 project evaluation into clearly-stated design choices, placed where evaluators actually look. **Placement/surfacing only — no new claims, no `render.py`/report-output changes.**

### README — new "What Praxen is (and isn't)" section
- **Decision support, not an enforcement gate** — findings + RAISE score are model-assisted expert judgments, not a deterministic pass/fail (links the existing variability + challenging-findings docs).
- **Read-only by design, by convention not a sandbox** — runs inside your coding agent with its normal tool access; run it where you'd trust that agent (links SECURITY).

### SECURITY.md — new "Security model and assumptions" section
- Lifts the existing `PRAXEN_SPEC` "behavioral contract … not a technical sandbox … enforced by convention rather than an isolation boundary" language so security reviewers find it in the doc they read.
- Adds "local by default / nothing phones home" and cross-links the README section.

Cross-link anchors verified; linked docs (`understanding-variability.md`, `challenging-findings.md`) confirmed present.

Targets `dev`. **For review — not merging yet.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)