### PR TITLE
Promote dev → main: positioning docs (#165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ Each finding is tagged against the **OWASP Top 10 for LLM Applications 2025**, *
 
 ---
 
+## Working with Praxen
+
+Praxen produces an **expert review that focuses human attention.** Each report is a model-assisted analysis of where an agent's behavior may diverge from its remit. Treat the findings and RAISE maturity score as judgments to act on — a senior reviewer's notes, not an automated pass/fail. Scores are calibrated per model tier and vary run to run ([details](docs/understanding-variability.md)), and you can [challenge and revise any finding](docs/challenging-findings.md).
+
+Praxen works by **reading your agent's real workspace in place** — its actual code, config, and logs. It writes findings only to `./reports/` and never modifies the agent. It runs as a skill inside your coding agent, using that agent's own tools rather than a separate sandbox, so run Praxen where you already trust that agent to operate. The [security model and assumptions](SECURITY.md#security-model-and-assumptions) covers this in full.
+
+---
+
 ## Get started
 
 - [**Installation**](docs/installation.md) — Claude Code or OpenAI Codex (plugin marketplace), or any other agent (point it at the repo)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,6 +7,15 @@
 
 Praxen is a security tool. We take vulnerabilities in Praxen itself seriously. This document describes how to report one privately, what is in scope, and what to expect after you report.
 
+## Security model and assumptions
+
+Praxen runs as a skill *inside* your coding agent (Claude Code, OpenAI Codex, or similar) — not as a standalone, sandboxed service. Two properties are worth stating plainly before you run it:
+
+- **Read-only by convention, not by isolation.** Praxen is designed to operate read-only on the agent's workspace: it reads artifacts (code, config, logs, governance docs) and writes output only to its own `./reports/` directory. It does not act on the agent's behalf and does not modify the agent's code, skill files, configuration, or dependencies. But this is a **behavioral contract of the skill's instructions, not a technical sandbox** — Praxen runs with the coding agent's ordinary tool access (including Bash and Write), so the read-only posture is enforced by convention rather than by an isolation boundary. (This is the same declared-versus-enforced distinction Praxen itself flags when it scans other agents.) Run Praxen only where you already trust the coding agent to operate.
+- **Local by default.** Reports are written locally to `./reports/` (HTML, JSON, text). Nothing phones home.
+
+For guidance on interpreting Praxen's *output* — a model-assisted expert review rather than a deterministic gate — see [Working with Praxen](README.md#working-with-praxen).
+
 ## Scope
 
 **In scope** — vulnerabilities in Praxen itself:

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@
 | Looking at a report and trying to understand it | [Interpreting Reports](interpreting-reports.md) |
 | Disagreeing with a finding or wanting to revise it | [Challenging and Revising Findings](challenging-findings.md) |
 | Wondering why two runs gave slightly different scores | [Understanding Run-to-Run Variability](understanding-variability.md) |
+| Getting the most out of a Praxen report | [Working with Praxen](#working-with-praxen) |
 | Hit a problem on a first run | [Usage § Troubleshooting](usage.md#troubleshooting) |
 | Trying to understand the OWASP frameworks Praxen tags against | [OWASP Gen AI Security](owasp.md) |
 | Trying to understand the RAISE maturity scoring | [The RAISE Framework](RAISE.md) |
@@ -46,6 +47,12 @@ flowchart LR
 ```
 
 The output is a self-contained HTML analysis report, a machine-readable findings JSON, and a plain-text summary. Open the HTML in a browser; ingest the JSON in your pipeline.
+
+## Working with Praxen
+
+Praxen produces an **expert review that focuses human attention.** Each report is a model-assisted analysis of where an agent's behavior may diverge from its remit. Treat the findings and RAISE maturity score as judgments to act on — a senior reviewer's notes, not an automated pass/fail. Scores are calibrated per model tier and vary run to run (see [Understanding Run-to-Run Variability](understanding-variability.md)), and you can [challenge and revise any finding](challenging-findings.md).
+
+Praxen works by **reading your agent's real workspace in place** — its actual code, config, and logs. It writes findings only to `./reports/` and never modifies the agent. It runs as a skill inside your coding agent, using that agent's own tools rather than a separate sandbox, so run Praxen where you already trust that agent to operate. The [security model and assumptions](../SECURITY.md#security-model-and-assumptions) covers this in full.
 
 ## Four input shapes
 

--- a/guide/index.html
+++ b/guide/index.html
@@ -243,7 +243,7 @@ img { max-width: 100%; display: block; }
   </div>
 </header>
 <div class="docs-shell">
-  <aside class="docs-sidebar"><nav class="docs-nav"><div class="docs-nav-title">Documentation</div><ul><li><a href="index.html" class="active">Overview</a><ul class="docs-subnav"><li><a href="#where-to-start">Where to start</a></li><li><a href="#how-praxen-works-in-90-seconds">How Praxen works (in 90 seconds)</a></li><li><a href="#four-input-shapes">Four input shapes</a></li><li><a href="#frameworks">Frameworks</a></li><li><a href="#quick-reference">Quick reference</a></li></ul></li><li><a href="installation.html">Installation</a></li><li><a href="quickstart.html">Quickstart</a></li><li><a href="usage.html">Usage</a></li><li><a href="writing-remits.html">Writing Worker Remits</a></li><li><a href="interpreting-reports.html">Interpreting Reports</a></li><li><a href="challenging-findings.html">Challenging Findings</a></li><li><a href="understanding-variability.html">Run-to-Run Variability</a></li><li><a href="abv.html">Agent Behavior Verification</a></li><li><a href="owasp.html">OWASP Gen AI Security</a></li><li><a href="RAISE.html">The RAISE Framework</a></li></ul></nav></aside>
+  <aside class="docs-sidebar"><nav class="docs-nav"><div class="docs-nav-title">Documentation</div><ul><li><a href="index.html" class="active">Overview</a><ul class="docs-subnav"><li><a href="#where-to-start">Where to start</a></li><li><a href="#how-praxen-works-in-90-seconds">How Praxen works (in 90 seconds)</a></li><li><a href="#working-with-praxen">Working with Praxen</a></li><li><a href="#four-input-shapes">Four input shapes</a></li><li><a href="#frameworks">Frameworks</a></li><li><a href="#quick-reference">Quick reference</a></li></ul></li><li><a href="installation.html">Installation</a></li><li><a href="quickstart.html">Quickstart</a></li><li><a href="usage.html">Usage</a></li><li><a href="writing-remits.html">Writing Worker Remits</a></li><li><a href="interpreting-reports.html">Interpreting Reports</a></li><li><a href="challenging-findings.html">Challenging Findings</a></li><li><a href="understanding-variability.html">Run-to-Run Variability</a></li><li><a href="abv.html">Agent Behavior Verification</a></li><li><a href="owasp.html">OWASP Gen AI Security</a></li><li><a href="RAISE.html">The RAISE Framework</a></li></ul></nav></aside>
   <main class="docs-main">
     <article class="prose"><h1 id="praxen-documentation">Praxen Documentation</h1>
 <p><strong>Praxen</strong> is the open-source reference implementation of <strong><a href="abv.html">Agent Behavior Verification (ABV)</a></strong> — a proactive control model for AI agents and digital workers. It compares an AI agent's declared policy (a Worker Remit) against whatever evidence is available about that agent — source code, live deployment state, behavioral artifacts, governance docs, or any mix — and reports where observed behavior diverges from declared intent.</p>
@@ -293,6 +293,10 @@ img { max-width: 100%; display: block; }
 <td><a href="understanding-variability.html">Understanding Run-to-Run Variability</a></td>
 </tr>
 <tr>
+<td>Getting the most out of a Praxen report</td>
+<td><a href="#working-with-praxen">Working with Praxen</a></td>
+</tr>
+<tr>
 <td>Hit a problem on a first run</td>
 <td><a href="usage.html#troubleshooting">Usage § Troubleshooting</a></td>
 </tr>
@@ -322,6 +326,9 @@ img { max-width: 100%; display: block; }
   R --> TXT["analysis.txt"]
 </pre>
 <p>The output is a self-contained HTML analysis report, a machine-readable findings JSON, and a plain-text summary. Open the HTML in a browser; ingest the JSON in your pipeline.</p>
+<h2 id="working-with-praxen">Working with Praxen</h2>
+<p>Praxen produces an <strong>expert review that focuses human attention.</strong> Each report is a model-assisted analysis of where an agent's behavior may diverge from its remit. Treat the findings and RAISE maturity score as judgments to act on — a senior reviewer's notes, not an automated pass/fail. Scores are calibrated per model tier and vary run to run (see <a href="understanding-variability.html">Understanding Run-to-Run Variability</a>), and you can <a href="challenging-findings.html">challenge and revise any finding</a>.</p>
+<p>Praxen works by <strong>reading your agent's real workspace in place</strong> — its actual code, config, and logs. It writes findings only to <code>./reports/</code> and never modifies the agent. It runs as a skill inside your coding agent, using that agent's own tools rather than a separate sandbox, so run Praxen where you already trust that agent to operate. The <a href="https://github.com/open-agent-ai-security/praxen/blob/main/SECURITY.md#security-model-and-assumptions">security model and assumptions</a> covers this in full.</p>
 <h2 id="four-input-shapes">Four input shapes</h2>
 <p>Praxen is <strong>not just a source-code analyzer.</strong> Any of these — alone or in combination — are valid input:</p>
 <ul>


### PR DESCRIPTION
Promotes `dev` to `main` for the positioning/docs change (#165) — "Working with Praxen" section on README + Docs home, "Security model and assumptions" in SECURITY.md, rebuilt `guide/`. Merge with a **merge commit** (not squash); `dev` fast-forwarded back afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)