### PR TITLE
release-prep: refresh generated guide/ for Praxen 1.1.0

### DIFF
--- a/guide/RAISE.html
+++ b/guide/RAISE.html
@@ -224,6 +224,12 @@ img { max-width: 100%; display: block; }
     padding: 20px 0; border-bottom: 1px solid var(--border); }
   .docs-main { padding-top: 26px; }
 }
+
+
+/* Report masthead — minimal word-mark header for the hosted coverage pages. */
+.report-page .pmast { display: flex; align-items: center; padding: 16px 0 14px; margin-bottom: 6px; border-bottom: 1px solid var(--border); }
+.report-page .pmast-brand { display: inline-flex; align-items: center; }
+.report-page .pmast img { height: 26px; width: auto; display: block; }
 </style>
 <!-- Cookieless web analytics — docs/landing pages only, never the reports.
      Two tools run side by side (temporary A/B comparison):

--- a/guide/abv.html
+++ b/guide/abv.html
@@ -224,6 +224,12 @@ img { max-width: 100%; display: block; }
     padding: 20px 0; border-bottom: 1px solid var(--border); }
   .docs-main { padding-top: 26px; }
 }
+
+
+/* Report masthead — minimal word-mark header for the hosted coverage pages. */
+.report-page .pmast { display: flex; align-items: center; padding: 16px 0 14px; margin-bottom: 6px; border-bottom: 1px solid var(--border); }
+.report-page .pmast-brand { display: inline-flex; align-items: center; }
+.report-page .pmast img { height: 26px; width: auto; display: block; }
 </style>
 <!-- Cookieless web analytics — docs/landing pages only, never the reports.
      Two tools run side by side (temporary A/B comparison):

--- a/guide/challenging-findings.html
+++ b/guide/challenging-findings.html
@@ -224,6 +224,12 @@ img { max-width: 100%; display: block; }
     padding: 20px 0; border-bottom: 1px solid var(--border); }
   .docs-main { padding-top: 26px; }
 }
+
+
+/* Report masthead — minimal word-mark header for the hosted coverage pages. */
+.report-page .pmast { display: flex; align-items: center; padding: 16px 0 14px; margin-bottom: 6px; border-bottom: 1px solid var(--border); }
+.report-page .pmast-brand { display: inline-flex; align-items: center; }
+.report-page .pmast img { height: 26px; width: auto; display: block; }
 </style>
 <!-- Cookieless web analytics — docs/landing pages only, never the reports.
      Two tools run side by side (temporary A/B comparison):

--- a/guide/index.html
+++ b/guide/index.html
@@ -224,6 +224,12 @@ img { max-width: 100%; display: block; }
     padding: 20px 0; border-bottom: 1px solid var(--border); }
   .docs-main { padding-top: 26px; }
 }
+
+
+/* Report masthead — minimal word-mark header for the hosted coverage pages. */
+.report-page .pmast { display: flex; align-items: center; padding: 16px 0 14px; margin-bottom: 6px; border-bottom: 1px solid var(--border); }
+.report-page .pmast-brand { display: inline-flex; align-items: center; }
+.report-page .pmast img { height: 26px; width: auto; display: block; }
 </style>
 <!-- Cookieless web analytics — docs/landing pages only, never the reports.
      Two tools run side by side (temporary A/B comparison):

--- a/guide/installation.html
+++ b/guide/installation.html
@@ -224,6 +224,12 @@ img { max-width: 100%; display: block; }
     padding: 20px 0; border-bottom: 1px solid var(--border); }
   .docs-main { padding-top: 26px; }
 }
+
+
+/* Report masthead — minimal word-mark header for the hosted coverage pages. */
+.report-page .pmast { display: flex; align-items: center; padding: 16px 0 14px; margin-bottom: 6px; border-bottom: 1px solid var(--border); }
+.report-page .pmast-brand { display: inline-flex; align-items: center; }
+.report-page .pmast img { height: 26px; width: auto; display: block; }
 </style>
 <!-- Cookieless web analytics — docs/landing pages only, never the reports.
      Two tools run side by side (temporary A/B comparison):

--- a/guide/interpreting-reports.html
+++ b/guide/interpreting-reports.html
@@ -224,6 +224,12 @@ img { max-width: 100%; display: block; }
     padding: 20px 0; border-bottom: 1px solid var(--border); }
   .docs-main { padding-top: 26px; }
 }
+
+
+/* Report masthead — minimal word-mark header for the hosted coverage pages. */
+.report-page .pmast { display: flex; align-items: center; padding: 16px 0 14px; margin-bottom: 6px; border-bottom: 1px solid var(--border); }
+.report-page .pmast-brand { display: inline-flex; align-items: center; }
+.report-page .pmast img { height: 26px; width: auto; display: block; }
 </style>
 <!-- Cookieless web analytics — docs/landing pages only, never the reports.
      Two tools run side by side (temporary A/B comparison):

--- a/guide/owasp.html
+++ b/guide/owasp.html
@@ -224,6 +224,12 @@ img { max-width: 100%; display: block; }
     padding: 20px 0; border-bottom: 1px solid var(--border); }
   .docs-main { padding-top: 26px; }
 }
+
+
+/* Report masthead — minimal word-mark header for the hosted coverage pages. */
+.report-page .pmast { display: flex; align-items: center; padding: 16px 0 14px; margin-bottom: 6px; border-bottom: 1px solid var(--border); }
+.report-page .pmast-brand { display: inline-flex; align-items: center; }
+.report-page .pmast img { height: 26px; width: auto; display: block; }
 </style>
 <!-- Cookieless web analytics — docs/landing pages only, never the reports.
      Two tools run side by side (temporary A/B comparison):

--- a/guide/quickstart.html
+++ b/guide/quickstart.html
@@ -224,6 +224,12 @@ img { max-width: 100%; display: block; }
     padding: 20px 0; border-bottom: 1px solid var(--border); }
   .docs-main { padding-top: 26px; }
 }
+
+
+/* Report masthead — minimal word-mark header for the hosted coverage pages. */
+.report-page .pmast { display: flex; align-items: center; padding: 16px 0 14px; margin-bottom: 6px; border-bottom: 1px solid var(--border); }
+.report-page .pmast-brand { display: inline-flex; align-items: center; }
+.report-page .pmast img { height: 26px; width: auto; display: block; }
 </style>
 <!-- Cookieless web analytics — docs/landing pages only, never the reports.
      Two tools run side by side (temporary A/B comparison):

--- a/guide/understanding-variability.html
+++ b/guide/understanding-variability.html
@@ -224,6 +224,12 @@ img { max-width: 100%; display: block; }
     padding: 20px 0; border-bottom: 1px solid var(--border); }
   .docs-main { padding-top: 26px; }
 }
+
+
+/* Report masthead — minimal word-mark header for the hosted coverage pages. */
+.report-page .pmast { display: flex; align-items: center; padding: 16px 0 14px; margin-bottom: 6px; border-bottom: 1px solid var(--border); }
+.report-page .pmast-brand { display: inline-flex; align-items: center; }
+.report-page .pmast img { height: 26px; width: auto; display: block; }
 </style>
 <!-- Cookieless web analytics — docs/landing pages only, never the reports.
      Two tools run side by side (temporary A/B comparison):

--- a/guide/usage.html
+++ b/guide/usage.html
@@ -224,6 +224,12 @@ img { max-width: 100%; display: block; }
     padding: 20px 0; border-bottom: 1px solid var(--border); }
   .docs-main { padding-top: 26px; }
 }
+
+
+/* Report masthead — minimal word-mark header for the hosted coverage pages. */
+.report-page .pmast { display: flex; align-items: center; padding: 16px 0 14px; margin-bottom: 6px; border-bottom: 1px solid var(--border); }
+.report-page .pmast-brand { display: inline-flex; align-items: center; }
+.report-page .pmast img { height: 26px; width: auto; display: block; }
 </style>
 <!-- Cookieless web analytics — docs/landing pages only, never the reports.
      Two tools run side by side (temporary A/B comparison):

--- a/guide/writing-remits.html
+++ b/guide/writing-remits.html
@@ -224,6 +224,12 @@ img { max-width: 100%; display: block; }
     padding: 20px 0; border-bottom: 1px solid var(--border); }
   .docs-main { padding-top: 26px; }
 }
+
+
+/* Report masthead — minimal word-mark header for the hosted coverage pages. */
+.report-page .pmast { display: flex; align-items: center; padding: 16px 0 14px; margin-bottom: 6px; border-bottom: 1px solid var(--border); }
+.report-page .pmast-brand { display: inline-flex; align-items: center; }
+.report-page .pmast img { height: 26px; width: auto; display: block; }
 </style>
 <!-- Cookieless web analytics — docs/landing pages only, never the reports.
      Two tools run side by side (temporary A/B comparison):


### PR DESCRIPTION
## Why

The `v1.1.0` release build failed at the docs-freshness backstop: the shared docs theme gained a `.report-page` masthead CSS block that was never propagated into the committed `guide/*.html`, so `build.sh` → `docs_build.py` detected drift and blocked the release (no GitHub release was published — the build step failed before it).

```
error: guide/ is out of date with docs/*.md (or the shared theme).
```

## What

Regenerated `guide/` via `docs_build.py`. **Purely additive generated-HTML** — +66 lines across 11 pages, all the same masthead CSS block. No source or content change.

## After merge

- ff-sync `dev` back up to `main` (branch-drift invariant)
- move the `v1.1.0` tag to the new `main` HEAD → re-triggers the Release workflow, which will pass the freshness gate and publish the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)