### PR TITLE
news: add DBTA editorial coverage

### DIFF
--- a/news.html
+++ b/news.html
@@ -161,7 +161,7 @@
         </p>
         <div class="topline">
           <div class="stat"><strong>35+</strong><span>placements</span></div>
-          <div class="stat"><strong>15</strong><span>editorial features</span></div>
+          <div class="stat"><strong>16</strong><span>editorial features</span></div>
           <div class="stat"><strong>June 2026</strong><span>launch window</span></div>
         </div>
       </div>
@@ -257,6 +257,11 @@
           <a class="cov-card" href="https://byteiota.com/praxen-open-source-ai-agent-behavior-verification-explained/" target="_blank" rel="noopener">
             <div class="cov-outlet">ByteIota</div>
             <p class="cov-title">Praxen: Open-Source AI Agent Behavior Verification Explained</p>
+            <span class="cov-read">Read →</span>
+          </a>
+          <a class="cov-card" href="https://www.dbta.com/Editorial/News-Flashes/Exabeam-Introduces-Open-Source-Tool-to-Bring-Agent-Behavior-Verification-to-AI-Agents-and-Digital-Workers-175691.aspx" target="_blank" rel="noopener">
+            <div class="cov-outlet">Database Trends &amp; Applications</div>
+            <p class="cov-title">Exabeam Introduces Open Source Tool to Bring Agent Behavior Verification to AI Agents and Digital Workers</p>
             <span class="cov-read">Read →</span>
           </a>
         </div>


### PR DESCRIPTION
Adds a new **Editorial coverage** card for the Database Trends & Applications piece:

- **Outlet:** Database Trends & Applications (DBTA)
- **Author:** Stephanie Simone · **Date:** July 13, 2026
- **Headline:** *Exabeam Introduces Open Source Tool to Bring Agent Behavior Verification to AI Agents and Digital Workers*
- [Article](https://www.dbta.com/Editorial/News-Flashes/Exabeam-Introduces-Open-Source-Tool-to-Bring-Agent-Behavior-Verification-to-AI-Agents-and-Digital-Workers-175691.aspx)

Also bumps the topline **editorial features** count 15 → 16 to match. Card placed at the end of the editorial grid; markup mirrors the existing `.cov-card` pattern. Targets `dev` per the news-page convention (reaches the live site at the next dev→main promotion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)