### PR TITLE
Promote dev → main: DBTA editorial news card

### DIFF
--- a/news.html
+++ b/news.html
@@ -161,7 +161,7 @@
         </p>
         <div class="topline">
           <div class="stat"><strong>35+</strong><span>placements</span></div>
-          <div class="stat"><strong>15</strong><span>editorial features</span></div>
+          <div class="stat"><strong>16</strong><span>editorial features</span></div>
           <div class="stat"><strong>June 2026</strong><span>launch window</span></div>
         </div>
       </div>
@@ -257,6 +257,11 @@
           <a class="cov-card" href="https://byteiota.com/praxen-open-source-ai-agent-behavior-verification-explained/" target="_blank" rel="noopener">
             <div class="cov-outlet">ByteIota</div>
             <p class="cov-title">Praxen: Open-Source AI Agent Behavior Verification Explained</p>
+            <span class="cov-read">Read →</span>
+          </a>
+          <a class="cov-card" href="https://www.dbta.com/Editorial/News-Flashes/Exabeam-Introduces-Open-Source-Tool-to-Bring-Agent-Behavior-Verification-to-AI-Agents-and-Digital-Workers-175691.aspx" target="_blank" rel="noopener">
+            <div class="cov-outlet">Database Trends &amp; Applications</div>
+            <p class="cov-title">Exabeam Introduces Open Source Tool to Bring Agent Behavior Verification to AI Agents and Digital Workers</p>
             <span class="cov-read">Read →</span>
           </a>
         </div>


### PR DESCRIPTION
Low-impact promotion — publishes the new **Database Trends & Applications** editorial card on the live news page (#179).

Single change: one `.cov-card` + topline count 15 → 16 in `news.html`. No code/schema/version changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)