### PR TITLE
news: add 'When OWASP LLM Risks Meet Agentic Risks' commentary

### DIFF
--- a/news.html
+++ b/news.html
@@ -298,6 +298,11 @@
             <p class="cov-title">The Scanner, the SOC Agent, and the Prompt That Lied — a Praxen maturity scan (1.85 → 2.75) shows why deterministic guardrails beat prompt-only enforcement</p>
             <span class="cov-read">Read →</span>
           </a>
+          <a class="cov-card" href="https://www.linkedin.com/pulse/when-owasp-llm-risks-meet-agentic-steve-wilson-wkeec/" target="_blank" rel="noopener">
+            <div class="cov-outlet">Steve Wilson · LinkedIn</div>
+            <p class="cov-title">When OWASP LLM Risks Meet Agentic Risks — the LLM and Agentic Top 10s are complementary layers, shown through Praxen 1.1 testing where Excessive Agency and Unexpected Code Execution rise to the top</p>
+            <span class="cov-read">Read →</span>
+          </a>
           <a class="cov-card" href="https://x.com/kameki23/status/2071066154697974018" target="_blank" rel="noopener">
             <div class="cov-outlet">Kameda Naoki (@kameki23) · X</div>
             <p class="cov-title">AI agent behavior verification, achieved in open source — this could change the future of AI (Japanese-language thread)</p>


### PR DESCRIPTION
Adds an **Industry commentary** card for Steve Wilson's LinkedIn Pulse piece:

- **When OWASP LLM Risks Meet Agentic Risks** — Steve Wilson · LinkedIn
- [Article](https://www.linkedin.com/pulse/when-owasp-llm-risks-meet-agentic-steve-wilson-wkeec/)

Grouped next to the existing Steve Wilson commentary card; markup mirrors the existing `.cov-card` pattern. Commentary (not editorial), so no topline-count change. Targets `dev` per the news-page convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)