### PR TITLE
seo: canonical/OG/JSON-LD metadata, sitemap.xml, llms.txt for GEO

### DIFF
--- a/docs_build.py
+++ b/docs_build.py
@@ -15,11 +15,17 @@ generators. A left-nav lists every doc (the current one expanded into its
 section TOC); cross-doc `*.md` links are rewritten to `*.html`, and links to
 repo files (`../FOO.md`) are pointed at the GitHub blob view.
 
+Each page also gets an auto-derived meta description (from its first <p>), a
+canonical link, Open Graph / Twitter Card tags, and a TechArticle JSON-LD
+block, for search engines and AI/LLM answer engines (GEO). The same PAGES list
+also drives sitemap.xml, written to the repo root alongside guide/.
+
 Edit the docs in markdown; regenerate at release time:
 
     python3 docs_build.py
 """
 import html
+import json
 import re
 import sys
 from pathlib import Path
@@ -36,6 +42,8 @@ DOCS_DIR = ROOT / "docs"
 OUT_DIR = ROOT / "guide"
 THEME_CSS = ROOT / "assets" / "praxen-theme.css"
 REPO = "https://github.com/open-agent-ai-security/praxen"
+SITE_URL = "https://open-agent-ai-security.github.io/praxen/"
+SOCIAL_IMAGE = "graphics/praxen-social.png"
 
 # Ordered table of contents for the left-nav: (source file, nav label).
 PAGES = [
@@ -154,6 +162,22 @@ def onpage_toc(toc_tokens) -> str:
     return f'<ul class="docs-subnav">{lis}</ul>'
 
 
+TAG_RE = re.compile(r"<[^>]+>")
+WHITESPACE_RE = re.compile(r"\s+")
+
+
+def meta_description(body: str, fallback: str, limit: int = 155) -> str:
+    """Derive a meta/OG description from the page's first <p>, falling back to
+    `fallback` (the nav label) if the page has none. Plain text, collapsed
+    whitespace, truncated on a word boundary — never mid-word."""
+    m = re.search(r"<p[^>]*>(.*?)</p>", body, re.DOTALL)
+    text = html.unescape(TAG_RE.sub("", m.group(1))).strip() if m else ""
+    text = WHITESPACE_RE.sub(" ", text) or fallback
+    if len(text) <= limit:
+        return text
+    return text[:limit].rsplit(" ", 1)[0].rstrip(",;:.") + "…"
+
+
 def left_nav(active_file: str, active_toc: str) -> str:
     out = ['<nav class="docs-nav"><div class="docs-nav-title">Documentation</div><ul>']
     for src, label in PAGES:
@@ -168,14 +192,52 @@ def left_nav(active_file: str, active_toc: str) -> str:
     return "".join(out)
 
 
-def page_html(theme_css: str, title: str, nav: str, body: str, src: str, body_end: str = "") -> str:
+def page_html(theme_css: str, title: str, nav: str, body: str, src: str, description: str, body_end: str = "") -> str:
     edit_url = f"{REPO}/blob/main/docs/{src}"
+    out_rel = src[:-3] + ".html"
+    full_title = f"{html.escape(title)} · Praxen Docs"
+    canonical = f"{SITE_URL}guide/{out_rel}"
+    desc_attr = html.escape(description, quote=True)
+    image_url = f"{SITE_URL}{SOCIAL_IMAGE}"
+    # TechArticle: this is reference/how-to documentation, not editorial content,
+    # and has no reliable per-page date (a git-log-derived date would drift
+    # between a full local clone and CI's shallow checkout and make the
+    # docs-freshness gate flap on unrelated grounds). NB: script content is raw
+    # text per the HTML spec (entities are NOT decoded inside <script>), so JSON
+    # values here must go through json.dumps, never html.escape — an
+    # html-escaped quote would land in the DOM as the literal text `&quot;` and
+    # break JSON.parse.
+    json_ld = f"""<script type="application/ld+json">
+{{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": {json.dumps(title)},
+  "description": {json.dumps(description)},
+  "url": {json.dumps(canonical)},
+  "isPartOf": {{ "@type": "WebSite", "name": "Praxen", "url": {json.dumps(SITE_URL)} }},
+  "publisher": {{ "@type": "Organization", "name": "Exabeam", "url": "https://www.exabeam.com/" }}
+}}
+</script>"""
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>{html.escape(title)} · Praxen Docs</title>
+<title>{full_title}</title>
+<meta name="description" content="{desc_attr}">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="{canonical}">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Praxen">
+<meta property="og:title" content="{full_title}">
+<meta property="og:description" content="{desc_attr}">
+<meta property="og:url" content="{canonical}">
+<meta property="og:image" content="{image_url}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{full_title}">
+<meta name="twitter:description" content="{desc_attr}">
+<meta name="twitter:image" content="{image_url}">
+{json_ld}
 <style>{theme_css}</style>
 <!-- Cookieless web analytics — docs/landing pages only, never the reports.
      Two tools run side by side (temporary A/B comparison):
@@ -230,6 +292,8 @@ def build():
         output_format="html5",
     )
 
+    sitemap_urls = ["", "news.html"]  # site root pages, relative to SITE_URL
+
     for src, label in PAGES:
         text = (DOCS_DIR / src).read_text(encoding="utf-8")
         text = LEADING_COMMENT.sub("", text, count=1)  # drop the license header comment
@@ -241,12 +305,40 @@ def build():
         m = re.search(r"<h1[^>]*>(.*?)</h1>", body, re.DOTALL)
         # The H1 is already HTML-escaped; unescape before page_html re-escapes it.
         title = html.unescape(re.sub(r"<[^>]+>", "", m.group(1))).strip() if m else label
+        description = meta_description(body, label)
 
         nav = left_nav(src, onpage_toc(md.toc_tokens))
-        out_path = OUT_DIR / (src[:-3] + ".html")
+        out_rel = src[:-3] + ".html"
+        out_path = OUT_DIR / out_rel
         body_end = MERMAID_SCRIPT if has_mermaid else ""
-        out_path.write_text(page_html(theme_css, title, nav, body, src, body_end), encoding="utf-8")
+        out_path.write_text(page_html(theme_css, title, nav, body, src, description, body_end), encoding="utf-8")
         print(f"docs_build.py: wrote {out_path.relative_to(ROOT)}")
+        sitemap_urls.append(f"guide/{out_rel}")
+
+    # The two "📊 See it live" reports docs/index.md and docs/owasp.md and
+    # docs/RAISE.md link to prominently — static, checked-in HTML (not
+    # generated by this script) but genuinely public-facing, unlike the other
+    # tests/baselines/*.html health reports, which are CI-internal.
+    sitemap_urls.append("tests/baselines/owasp-coverage-report.html")
+    sitemap_urls.append("tests/baselines/raise-coverage-report.html")
+
+    write_sitemap(sitemap_urls)
+
+
+def write_sitemap(url_paths):
+    """Emit sitemap.xml at the repo root from the same PAGES list docs_build.py
+    already treats as the source of truth, so there is one place to update when
+    a page is added instead of a second list to keep in sync by hand."""
+    entries = "\n".join(f"  <url><loc>{html.escape(SITE_URL + p, quote=True)}</loc></url>" for p in url_paths)
+    sitemap = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+        f"{entries}\n"
+        "</urlset>\n"
+    )
+    out_path = ROOT / "sitemap.xml"
+    out_path.write_text(sitemap, encoding="utf-8")
+    print(f"docs_build.py: wrote {out_path.relative_to(ROOT)}")
 
 
 if __name__ == "__main__":

--- a/docs_build.py
+++ b/docs_build.py
@@ -192,6 +192,17 @@ def left_nav(active_file: str, active_toc: str) -> str:
     return "".join(out)
 
 
+def _jsonld_str(value: str) -> str:
+    """JSON-encode a string for embedding inside an HTML <script> block.
+
+    json.dumps handles the JSON quoting, but does NOT escape `/`, so a value
+    containing `</script>` (or any `</…`) would prematurely close the script
+    element and could inject markup. Escaping `</` as `<\\/` is valid JSON and
+    parses identically, while being inert to the HTML parser.
+    """
+    return json.dumps(value).replace("</", "<\\/")
+
+
 def page_html(theme_css: str, title: str, nav: str, body: str, src: str, description: str, body_end: str = "") -> str:
     edit_url = f"{REPO}/blob/main/docs/{src}"
     out_rel = src[:-3] + ".html"
@@ -206,15 +217,16 @@ def page_html(theme_css: str, title: str, nav: str, body: str, src: str, descrip
     # text per the HTML spec (entities are NOT decoded inside <script>), so JSON
     # values here must go through json.dumps, never html.escape — an
     # html-escaped quote would land in the DOM as the literal text `&quot;` and
-    # break JSON.parse.
+    # break JSON.parse. `_jsonld_str` additionally escapes `</` so a value
+    # containing `</script>` can't break out of the <script> element.
     json_ld = f"""<script type="application/ld+json">
 {{
   "@context": "https://schema.org",
   "@type": "TechArticle",
-  "headline": {json.dumps(title)},
-  "description": {json.dumps(description)},
-  "url": {json.dumps(canonical)},
-  "isPartOf": {{ "@type": "WebSite", "name": "Praxen", "url": {json.dumps(SITE_URL)} }},
+  "headline": {_jsonld_str(title)},
+  "description": {_jsonld_str(description)},
+  "url": {_jsonld_str(canonical)},
+  "isPartOf": {{ "@type": "WebSite", "name": "Praxen", "url": {_jsonld_str(SITE_URL)} }},
   "publisher": {{ "@type": "Organization", "name": "Exabeam", "url": "https://www.exabeam.com/" }}
 }}
 </script>"""

--- a/guide/RAISE.html
+++ b/guide/RAISE.html
@@ -4,6 +4,30 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>The RAISE Framework · Praxen Docs</title>
+<meta name="description" content="Praxen evaluates every AI agent against the Responsible AI Software Engineering (RAISE) framework — a six-category methodology for assessing AI system…">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://open-agent-ai-security.github.io/praxen/guide/RAISE.html">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Praxen">
+<meta property="og:title" content="The RAISE Framework · Praxen Docs">
+<meta property="og:description" content="Praxen evaluates every AI agent against the Responsible AI Software Engineering (RAISE) framework — a six-category methodology for assessing AI system…">
+<meta property="og:url" content="https://open-agent-ai-security.github.io/praxen/guide/RAISE.html">
+<meta property="og:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="The RAISE Framework · Praxen Docs">
+<meta name="twitter:description" content="Praxen evaluates every AI agent against the Responsible AI Software Engineering (RAISE) framework — a six-category methodology for assessing AI system…">
+<meta name="twitter:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "The RAISE Framework",
+  "description": "Praxen evaluates every AI agent against the Responsible AI Software Engineering (RAISE) framework \u2014 a six-category methodology for assessing AI system\u2026",
+  "url": "https://open-agent-ai-security.github.io/praxen/guide/RAISE.html",
+  "isPartOf": { "@type": "WebSite", "name": "Praxen", "url": "https://open-agent-ai-security.github.io/praxen/" },
+  "publisher": { "@type": "Organization", "name": "Exabeam", "url": "https://www.exabeam.com/" }
+}
+</script>
 <style>@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
 /*
   Copyright 2026 Exabeam, Inc.

--- a/guide/abv.html
+++ b/guide/abv.html
@@ -4,6 +4,30 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Agent Behavior Verification (ABV) · Praxen Docs</title>
+<meta name="description" content="Verifying that AI agents stay within their authorized role.">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://open-agent-ai-security.github.io/praxen/guide/abv.html">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Praxen">
+<meta property="og:title" content="Agent Behavior Verification (ABV) · Praxen Docs">
+<meta property="og:description" content="Verifying that AI agents stay within their authorized role.">
+<meta property="og:url" content="https://open-agent-ai-security.github.io/praxen/guide/abv.html">
+<meta property="og:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Agent Behavior Verification (ABV) · Praxen Docs">
+<meta name="twitter:description" content="Verifying that AI agents stay within their authorized role.">
+<meta name="twitter:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "Agent Behavior Verification (ABV)",
+  "description": "Verifying that AI agents stay within their authorized role.",
+  "url": "https://open-agent-ai-security.github.io/praxen/guide/abv.html",
+  "isPartOf": { "@type": "WebSite", "name": "Praxen", "url": "https://open-agent-ai-security.github.io/praxen/" },
+  "publisher": { "@type": "Organization", "name": "Exabeam", "url": "https://www.exabeam.com/" }
+}
+</script>
 <style>@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
 /*
   Copyright 2026 Exabeam, Inc.

--- a/guide/challenging-findings.html
+++ b/guide/challenging-findings.html
@@ -4,6 +4,30 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Challenging and Revising Findings · Praxen Docs</title>
+<meta name="description" content="Praxen is an LLM-driven analyzer working from the evidence you provide. It will sometimes produce findings that are wrong, miscalibrated, or inapplicable…">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://open-agent-ai-security.github.io/praxen/guide/challenging-findings.html">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Praxen">
+<meta property="og:title" content="Challenging and Revising Findings · Praxen Docs">
+<meta property="og:description" content="Praxen is an LLM-driven analyzer working from the evidence you provide. It will sometimes produce findings that are wrong, miscalibrated, or inapplicable…">
+<meta property="og:url" content="https://open-agent-ai-security.github.io/praxen/guide/challenging-findings.html">
+<meta property="og:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Challenging and Revising Findings · Praxen Docs">
+<meta name="twitter:description" content="Praxen is an LLM-driven analyzer working from the evidence you provide. It will sometimes produce findings that are wrong, miscalibrated, or inapplicable…">
+<meta name="twitter:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "Challenging and Revising Findings",
+  "description": "Praxen is an LLM-driven analyzer working from the evidence you provide. It will sometimes produce findings that are wrong, miscalibrated, or inapplicable\u2026",
+  "url": "https://open-agent-ai-security.github.io/praxen/guide/challenging-findings.html",
+  "isPartOf": { "@type": "WebSite", "name": "Praxen", "url": "https://open-agent-ai-security.github.io/praxen/" },
+  "publisher": { "@type": "Organization", "name": "Exabeam", "url": "https://www.exabeam.com/" }
+}
+</script>
 <style>@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
 /*
   Copyright 2026 Exabeam, Inc.

--- a/guide/index.html
+++ b/guide/index.html
@@ -4,6 +4,30 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Praxen Documentation · Praxen Docs</title>
+<meta name="description" content="Praxen is the open-source reference implementation of Agent Behavior Verification (ABV) — a proactive control model for AI agents and digital workers. It…">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://open-agent-ai-security.github.io/praxen/guide/index.html">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Praxen">
+<meta property="og:title" content="Praxen Documentation · Praxen Docs">
+<meta property="og:description" content="Praxen is the open-source reference implementation of Agent Behavior Verification (ABV) — a proactive control model for AI agents and digital workers. It…">
+<meta property="og:url" content="https://open-agent-ai-security.github.io/praxen/guide/index.html">
+<meta property="og:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Praxen Documentation · Praxen Docs">
+<meta name="twitter:description" content="Praxen is the open-source reference implementation of Agent Behavior Verification (ABV) — a proactive control model for AI agents and digital workers. It…">
+<meta name="twitter:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "Praxen Documentation",
+  "description": "Praxen is the open-source reference implementation of Agent Behavior Verification (ABV) \u2014 a proactive control model for AI agents and digital workers. It\u2026",
+  "url": "https://open-agent-ai-security.github.io/praxen/guide/index.html",
+  "isPartOf": { "@type": "WebSite", "name": "Praxen", "url": "https://open-agent-ai-security.github.io/praxen/" },
+  "publisher": { "@type": "Organization", "name": "Exabeam", "url": "https://www.exabeam.com/" }
+}
+</script>
 <style>@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
 /*
   Copyright 2026 Exabeam, Inc.

--- a/guide/installation.html
+++ b/guide/installation.html
@@ -4,6 +4,30 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Installation · Praxen Docs</title>
+<meta name="description" content="Praxen ships as a portable agent skill, packaged for both Claude Code and OpenAI Codex. Both platforms load the same skills/behavior-verifier engine and…">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://open-agent-ai-security.github.io/praxen/guide/installation.html">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Praxen">
+<meta property="og:title" content="Installation · Praxen Docs">
+<meta property="og:description" content="Praxen ships as a portable agent skill, packaged for both Claude Code and OpenAI Codex. Both platforms load the same skills/behavior-verifier engine and…">
+<meta property="og:url" content="https://open-agent-ai-security.github.io/praxen/guide/installation.html">
+<meta property="og:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Installation · Praxen Docs">
+<meta name="twitter:description" content="Praxen ships as a portable agent skill, packaged for both Claude Code and OpenAI Codex. Both platforms load the same skills/behavior-verifier engine and…">
+<meta name="twitter:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "Installation",
+  "description": "Praxen ships as a portable agent skill, packaged for both Claude Code and OpenAI Codex. Both platforms load the same skills/behavior-verifier engine and\u2026",
+  "url": "https://open-agent-ai-security.github.io/praxen/guide/installation.html",
+  "isPartOf": { "@type": "WebSite", "name": "Praxen", "url": "https://open-agent-ai-security.github.io/praxen/" },
+  "publisher": { "@type": "Organization", "name": "Exabeam", "url": "https://www.exabeam.com/" }
+}
+</script>
 <style>@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
 /*
   Copyright 2026 Exabeam, Inc.

--- a/guide/interpreting-reports.html
+++ b/guide/interpreting-reports.html
@@ -4,6 +4,30 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Interpreting Reports · Praxen Docs</title>
+<meta name="description" content="Praxen produces three output files per analysis: a findings JSON (the canonical, complete record — written by the skill), and — rendered deterministically…">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://open-agent-ai-security.github.io/praxen/guide/interpreting-reports.html">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Praxen">
+<meta property="og:title" content="Interpreting Reports · Praxen Docs">
+<meta property="og:description" content="Praxen produces three output files per analysis: a findings JSON (the canonical, complete record — written by the skill), and — rendered deterministically…">
+<meta property="og:url" content="https://open-agent-ai-security.github.io/praxen/guide/interpreting-reports.html">
+<meta property="og:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Interpreting Reports · Praxen Docs">
+<meta name="twitter:description" content="Praxen produces three output files per analysis: a findings JSON (the canonical, complete record — written by the skill), and — rendered deterministically…">
+<meta name="twitter:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "Interpreting Reports",
+  "description": "Praxen produces three output files per analysis: a findings JSON (the canonical, complete record \u2014 written by the skill), and \u2014 rendered deterministically\u2026",
+  "url": "https://open-agent-ai-security.github.io/praxen/guide/interpreting-reports.html",
+  "isPartOf": { "@type": "WebSite", "name": "Praxen", "url": "https://open-agent-ai-security.github.io/praxen/" },
+  "publisher": { "@type": "Organization", "name": "Exabeam", "url": "https://www.exabeam.com/" }
+}
+</script>
 <style>@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
 /*
   Copyright 2026 Exabeam, Inc.

--- a/guide/owasp.html
+++ b/guide/owasp.html
@@ -4,6 +4,30 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>OWASP Gen AI Security — the frameworks Praxen uses · Praxen Docs</title>
+<meta name="description" content="Every finding Praxen produces is tagged against industry-standard OWASP frameworks so the result lands in language your security team already speaks. This…">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://open-agent-ai-security.github.io/praxen/guide/owasp.html">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Praxen">
+<meta property="og:title" content="OWASP Gen AI Security — the frameworks Praxen uses · Praxen Docs">
+<meta property="og:description" content="Every finding Praxen produces is tagged against industry-standard OWASP frameworks so the result lands in language your security team already speaks. This…">
+<meta property="og:url" content="https://open-agent-ai-security.github.io/praxen/guide/owasp.html">
+<meta property="og:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="OWASP Gen AI Security — the frameworks Praxen uses · Praxen Docs">
+<meta name="twitter:description" content="Every finding Praxen produces is tagged against industry-standard OWASP frameworks so the result lands in language your security team already speaks. This…">
+<meta name="twitter:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "OWASP Gen AI Security \u2014 the frameworks Praxen uses",
+  "description": "Every finding Praxen produces is tagged against industry-standard OWASP frameworks so the result lands in language your security team already speaks. This\u2026",
+  "url": "https://open-agent-ai-security.github.io/praxen/guide/owasp.html",
+  "isPartOf": { "@type": "WebSite", "name": "Praxen", "url": "https://open-agent-ai-security.github.io/praxen/" },
+  "publisher": { "@type": "Organization", "name": "Exabeam", "url": "https://www.exabeam.com/" }
+}
+</script>
 <style>@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
 /*
   Copyright 2026 Exabeam, Inc.

--- a/guide/quickstart.html
+++ b/guide/quickstart.html
@@ -4,6 +4,30 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Quickstart — your first Praxen report in about 15 minutes · Praxen Docs</title>
+<meta name="description" content="A complete Praxen run, end to end: you&#x27;ll have Claude author a security policy for a real agent, verify the agent&#x27;s code against it, and read the report —…">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://open-agent-ai-security.github.io/praxen/guide/quickstart.html">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Praxen">
+<meta property="og:title" content="Quickstart — your first Praxen report in about 15 minutes · Praxen Docs">
+<meta property="og:description" content="A complete Praxen run, end to end: you&#x27;ll have Claude author a security policy for a real agent, verify the agent&#x27;s code against it, and read the report —…">
+<meta property="og:url" content="https://open-agent-ai-security.github.io/praxen/guide/quickstart.html">
+<meta property="og:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Quickstart — your first Praxen report in about 15 minutes · Praxen Docs">
+<meta name="twitter:description" content="A complete Praxen run, end to end: you&#x27;ll have Claude author a security policy for a real agent, verify the agent&#x27;s code against it, and read the report —…">
+<meta name="twitter:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "Quickstart \u2014 your first Praxen report in about 15 minutes",
+  "description": "A complete Praxen run, end to end: you'll have Claude author a security policy for a real agent, verify the agent's code against it, and read the report \u2014\u2026",
+  "url": "https://open-agent-ai-security.github.io/praxen/guide/quickstart.html",
+  "isPartOf": { "@type": "WebSite", "name": "Praxen", "url": "https://open-agent-ai-security.github.io/praxen/" },
+  "publisher": { "@type": "Organization", "name": "Exabeam", "url": "https://www.exabeam.com/" }
+}
+</script>
 <style>@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
 /*
   Copyright 2026 Exabeam, Inc.

--- a/guide/understanding-variability.html
+++ b/guide/understanding-variability.html
@@ -4,6 +4,30 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Understanding Run-to-Run Variability · Praxen Docs</title>
+<meta name="description" content="Run Praxen twice on the same agent, with the same Worker Remit and the same evidence, and the two reports will not be byte-identical. The big findings…">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://open-agent-ai-security.github.io/praxen/guide/understanding-variability.html">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Praxen">
+<meta property="og:title" content="Understanding Run-to-Run Variability · Praxen Docs">
+<meta property="og:description" content="Run Praxen twice on the same agent, with the same Worker Remit and the same evidence, and the two reports will not be byte-identical. The big findings…">
+<meta property="og:url" content="https://open-agent-ai-security.github.io/praxen/guide/understanding-variability.html">
+<meta property="og:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Understanding Run-to-Run Variability · Praxen Docs">
+<meta name="twitter:description" content="Run Praxen twice on the same agent, with the same Worker Remit and the same evidence, and the two reports will not be byte-identical. The big findings…">
+<meta name="twitter:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "Understanding Run-to-Run Variability",
+  "description": "Run Praxen twice on the same agent, with the same Worker Remit and the same evidence, and the two reports will not be byte-identical. The big findings\u2026",
+  "url": "https://open-agent-ai-security.github.io/praxen/guide/understanding-variability.html",
+  "isPartOf": { "@type": "WebSite", "name": "Praxen", "url": "https://open-agent-ai-security.github.io/praxen/" },
+  "publisher": { "@type": "Organization", "name": "Exabeam", "url": "https://www.exabeam.com/" }
+}
+</script>
 <style>@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
 /*
   Copyright 2026 Exabeam, Inc.

--- a/guide/usage.html
+++ b/guide/usage.html
@@ -4,6 +4,30 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Usage · Praxen Docs</title>
+<meta name="description" content="Running a Praxen analysis takes two inputs: a Worker Remit (the agent&#x27;s declared policy) and evidence (whatever the agent&#x27;s code, deployment state…">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://open-agent-ai-security.github.io/praxen/guide/usage.html">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Praxen">
+<meta property="og:title" content="Usage · Praxen Docs">
+<meta property="og:description" content="Running a Praxen analysis takes two inputs: a Worker Remit (the agent&#x27;s declared policy) and evidence (whatever the agent&#x27;s code, deployment state…">
+<meta property="og:url" content="https://open-agent-ai-security.github.io/praxen/guide/usage.html">
+<meta property="og:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Usage · Praxen Docs">
+<meta name="twitter:description" content="Running a Praxen analysis takes two inputs: a Worker Remit (the agent&#x27;s declared policy) and evidence (whatever the agent&#x27;s code, deployment state…">
+<meta name="twitter:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "Usage",
+  "description": "Running a Praxen analysis takes two inputs: a Worker Remit (the agent's declared policy) and evidence (whatever the agent's code, deployment state\u2026",
+  "url": "https://open-agent-ai-security.github.io/praxen/guide/usage.html",
+  "isPartOf": { "@type": "WebSite", "name": "Praxen", "url": "https://open-agent-ai-security.github.io/praxen/" },
+  "publisher": { "@type": "Organization", "name": "Exabeam", "url": "https://www.exabeam.com/" }
+}
+</script>
 <style>@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
 /*
   Copyright 2026 Exabeam, Inc.

--- a/guide/writing-remits.html
+++ b/guide/writing-remits.html
@@ -4,6 +4,30 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Writing Worker Remits · Praxen Docs</title>
+<meta name="description" content="The Worker Remit is the only artifact you customize per agent. Everything else in Praxen is generic. The quality of your remit directly determines the…">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://open-agent-ai-security.github.io/praxen/guide/writing-remits.html">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Praxen">
+<meta property="og:title" content="Writing Worker Remits · Praxen Docs">
+<meta property="og:description" content="The Worker Remit is the only artifact you customize per agent. Everything else in Praxen is generic. The quality of your remit directly determines the…">
+<meta property="og:url" content="https://open-agent-ai-security.github.io/praxen/guide/writing-remits.html">
+<meta property="og:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Writing Worker Remits · Praxen Docs">
+<meta name="twitter:description" content="The Worker Remit is the only artifact you customize per agent. Everything else in Praxen is generic. The quality of your remit directly determines the…">
+<meta name="twitter:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "Writing Worker Remits",
+  "description": "The Worker Remit is the only artifact you customize per agent. Everything else in Praxen is generic. The quality of your remit directly determines the\u2026",
+  "url": "https://open-agent-ai-security.github.io/praxen/guide/writing-remits.html",
+  "isPartOf": { "@type": "WebSite", "name": "Praxen", "url": "https://open-agent-ai-security.github.io/praxen/" },
+  "publisher": { "@type": "Organization", "name": "Exabeam", "url": "https://www.exabeam.com/" }
+}
+</script>
 <style>@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
 /*
   Copyright 2026 Exabeam, Inc.

--- a/index.html
+++ b/index.html
@@ -13,6 +13,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Praxen — AI Agent Behavior Verifier</title>
   <meta name="description" content="Praxen compares an AI agent's declared policy against real evidence — code, deployment state, behavioral logs — and reports exactly where behavior diverges from intent. Open-source agent behavior verification.">
+  <meta name="keywords" content="agent behavior verification, AI agent security, agentic AI security, AI agent behavior verifier, OWASP Top 10 for LLM Applications, OWASP Top 10 for Agentic AI Applications, OWASP Gen AI Security, MCP server security, prompt injection detection, RAISE framework, DevSecOps for AI agents, agent behavior drift detection">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://open-agent-ai-security.github.io/praxen/">
   <link rel="icon" type="image/png" sizes="32x32" href="graphics/web/favicon-32.png">
   <link rel="icon" type="image/png" sizes="256x256" href="graphics/web/favicon-256.png">
   <link rel="apple-touch-icon" sizes="180x180" href="graphics/web/favicon-180.png">
@@ -27,6 +30,34 @@
   <meta name="twitter:title" content="Praxen — AI Agent Behavior Verifier">
   <meta name="twitter:description" content="Make sure your agent does its job, and only its job.">
   <meta name="twitter:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+
+  <!-- Structured data: identifies Praxen as an open-source project (not a
+       hosted product) with its publisher, and lists the frameworks it
+       verifies against, for search engines and AI/LLM answer engines (GEO).
+       Kept deliberately free of date fields — see docs_build.py for why. -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareSourceCode",
+    "name": "Praxen",
+    "description": "Open-source Agent Behavior Verification (ABV). Compares an AI agent's declared policy (a Worker Remit) against real evidence — source code, live deployment state, behavioral artifacts, governance docs — and reports where observed behavior diverges from declared intent.",
+    "url": "https://open-agent-ai-security.github.io/praxen/",
+    "codeRepository": "https://github.com/open-agent-ai-security/praxen",
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+    "applicationCategory": "SecurityApplication",
+    "keywords": "agent behavior verification, AI agent security, OWASP Top 10 for LLM Applications, OWASP Top 10 for Agentic AI Applications, OWASP Gen AI Security, MCP server security, RAISE framework, DevSecOps for AI agents",
+    "author": {
+      "@type": "Organization",
+      "name": "Open Agent and AI Security Community",
+      "url": "https://open-agent-ai-security.github.io/"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Exabeam",
+      "url": "https://www.exabeam.com/"
+    }
+  }
+  </script>
 
   <!-- Preconnect warms the @import font fetch inside the shared theme below. -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,47 @@
+# Praxen
+
+> Open-source Agent Behavior Verification (ABV). Praxen compares an AI
+> agent's declared policy (a Worker Remit) against whatever evidence is
+> available about that agent — source code, live deployment state,
+> behavioral artifacts, or governance docs — and reports where observed
+> behavior diverges from declared intent. Open source (Apache-2.0),
+> distributed as a Claude Code plugin, maintained by the Open Agent and AI
+> Security Community (Exabeam-sponsored).
+
+Praxen answers a governance question traditional AppSec and runtime
+guardrails don't: is this agent operating within its authorized role? It
+reduces agent verification to one comparison — declared policy vs. observed
+evidence — and tags every finding against industry-standard frameworks:
+OWASP Top 10 for LLM Applications 2025, OWASP Top 10 for Agentic AI
+Applications 2026, OWASP's secure MCP server development guidance, and the
+six-category RAISE maturity framework.
+
+## Docs
+
+- [Overview](https://open-agent-ai-security.github.io/praxen/guide/index.html): what Praxen is and how it works
+- [What is Agent Behavior Verification?](https://open-agent-ai-security.github.io/praxen/guide/abv.html): the ABV concept, why agent security needs it
+- [Installation](https://open-agent-ai-security.github.io/praxen/guide/installation.html): install as a Claude Code plugin
+- [Quickstart](https://open-agent-ai-security.github.io/praxen/guide/quickstart.html): author a remit, scan an agent, read the report
+- [Usage](https://open-agent-ai-security.github.io/praxen/guide/usage.html): running a real analysis
+- [Writing Worker Remits](https://open-agent-ai-security.github.io/praxen/guide/writing-remits.html): declaring an agent's authorized policy
+- [Interpreting Reports](https://open-agent-ai-security.github.io/praxen/guide/interpreting-reports.html): reading findings and the RAISE score
+- [Challenging Findings](https://open-agent-ai-security.github.io/praxen/guide/challenging-findings.html): disputing or revising a finding
+- [Run-to-Run Variability](https://open-agent-ai-security.github.io/praxen/guide/understanding-variability.html): why scores vary between scans
+- [OWASP Gen AI Security](https://open-agent-ai-security.github.io/praxen/guide/owasp.html): the LLM/Agentic/MCP frameworks Praxen tags against
+- [The RAISE Framework](https://open-agent-ai-security.github.io/praxen/guide/RAISE.html): the six-category maturity scoring model
+
+## Live reports
+
+- [OWASP Coverage Report](https://open-agent-ai-security.github.io/praxen/tests/baselines/owasp-coverage-report.html): aggregate LLM/Agentic Top-10 coverage across Praxen's example suite
+- [RAISE Score Distribution Report](https://open-agent-ai-security.github.io/praxen/tests/baselines/raise-coverage-report.html): per-target RAISE scores across the baseline suite
+
+## Source
+
+- [GitHub repository](https://github.com/open-agent-ai-security/praxen)
+- [Full specification (PRAXEN_SPEC.md)](https://github.com/open-agent-ai-security/praxen/blob/main/PRAXEN_SPEC.md)
+- [Changelog](https://github.com/open-agent-ai-security/praxen/blob/main/CHANGELOG.md)
+
+## Optional
+
+- [In the news](https://open-agent-ai-security.github.io/praxen/news.html): third-party press and editorial coverage
+- [Open Agent and AI Security Community](https://open-agent-ai-security.github.io/): the org publishing Praxen and its sibling project, Observra

--- a/news.html
+++ b/news.html
@@ -15,6 +15,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Praxen — In the News</title>
   <meta name="description" content="Launch coverage for Praxen, the open-source Agent Behavior Verification (ABV) platform: SiliconANGLE, Help Net Security, Yahoo Finance, and more.">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://open-agent-ai-security.github.io/praxen/news.html">
   <link rel="icon" type="image/png" sizes="32x32" href="graphics/web/favicon-32.png">
   <link rel="icon" type="image/png" sizes="256x256" href="graphics/web/favicon-256.png">
   <link rel="apple-touch-icon" sizes="180x180" href="graphics/web/favicon-180.png">
@@ -28,6 +30,48 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Praxen — In the News">
   <meta name="twitter:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+
+  <!-- Structured data: lists the actual press mentions below as machine-readable
+       citations, so search/AI answer engines can attribute coverage correctly
+       instead of re-deriving it from prose. Kept in sync by hand with the cards
+       in the page body (this page is hand-authored, not generated). -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Praxen — In the News",
+    "url": "https://open-agent-ai-security.github.io/praxen/news.html",
+    "about": {
+      "@type": "SoftwareSourceCode",
+      "name": "Praxen",
+      "url": "https://open-agent-ai-security.github.io/praxen/"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Exabeam",
+      "url": "https://www.exabeam.com/"
+    },
+    "mentions": [
+      { "@type": "NewsArticle", "headline": "Exabeam Launches Open-Source Praxen to Bring Agent Behavior Verification to AI Agents and Digital Workers", "url": "https://www.exabeam.com/press-releases/exabeam-launches-open-source-praxen-to-bring-agent-behavior-verification-to-ai-agents-and-digital-workers/", "publisher": { "@type": "Organization", "name": "Exabeam" } },
+      { "@type": "NewsArticle", "headline": "Exabeam launches Praxen, an open-source tool to verify AI agent behavior", "url": "https://siliconangle.com/2026/06/23/exabeam-launches-praxen-open-source-tool-verify-ai-agent-behavior/", "publisher": { "@type": "Organization", "name": "SiliconANGLE" } },
+      { "@type": "NewsArticle", "headline": "Praxen: Open-source AI agent behavior verification", "url": "https://www.helpnetsecurity.com/2026/06/24/praxen-open-source-ai-agent-behavior-verification/", "publisher": { "@type": "Organization", "name": "Help Net Security" } },
+      { "@type": "NewsArticle", "headline": "Exabeam releases Praxen, an open-source tool for verifying AI agent behaviour before deployment", "url": "https://www.comparethecloud.net/news/exabeam-releases-praxen-an-open-source-tool-for-verifying-ai-agent-behaviour-before-deployment", "publisher": { "@type": "Organization", "name": "Compare the Cloud" } },
+      { "@type": "NewsArticle", "headline": "Exabeam launches open-source Praxen to verify AI agents", "url": "https://itbrief.com.au/story/exabeam-launches-open-source-praxen-to-verify-ai-agents", "publisher": { "@type": "Organization", "name": "IT Brief Australia" } },
+      { "@type": "NewsArticle", "headline": "Exabeam launches open-source Praxen to verify AI agents", "url": "https://securitybrief.asia/story/exabeam-launches-open-source-praxen-to-verify-ai-agents", "publisher": { "@type": "Organization", "name": "SecurityBrief Asia" } },
+      { "@type": "NewsArticle", "headline": "Exabeam releases open-source Praxen tool for AI agent behaviour verification", "url": "https://cyberriskleaders.com/exabeam-releases-open-source-praxen-tool-for-ai-agent-behaviour-verification/", "publisher": { "@type": "Organization", "name": "Cyber Risk Leaders" } },
+      { "@type": "NewsArticle", "headline": "Exabeam unveils open-source Praxen to establish Agent Behavior Verification for enterprise AI workers", "url": "https://aitech365.com/business-technology/cybersecurity/exabeam-unveils-open-source-praxen-to-establish-agent-behavior-verification-for-enterprise-ai-workers/", "publisher": { "@type": "Organization", "name": "AI Tech365" } },
+      { "@type": "NewsArticle", "headline": "Exabeam launches open-source Praxen for Agent Behavior Verification", "url": "https://techintelpro.com/news/cybersecurity/ai/exabeam-launches-open-source-praxen-for-agent-behavior-verification", "publisher": { "@type": "Organization", "name": "TechIntelPro" } },
+      { "@type": "NewsArticle", "headline": "Exabeam launches Praxen for AI agent security", "url": "https://soc-news.com/exabeam-launches-praxen-for-ai-agent-security/", "publisher": { "@type": "Organization", "name": "SOC News" } },
+      { "@type": "NewsArticle", "headline": "Exabeam launches open-source Praxen for AI agent verification", "url": "https://www.itnewsafrica.com/2026/06/exabeam-launches-open-source-praxen-for-ai-agent-verification/", "publisher": { "@type": "Organization", "name": "IT News Africa" } },
+      { "@type": "NewsArticle", "headline": "Praxen featured among the hottest open-source cybersecurity tools of June 2026", "url": "https://www.helpnetsecurity.com/2026/06/30/hottest-cybersecurity-open-source-tools-of-the-month-june-2026/", "publisher": { "@type": "Organization", "name": "Help Net Security" } },
+      { "@type": "NewsArticle", "headline": "Exabeam releases open-source Praxen to verify AI agent behaviour and security", "url": "https://www.sevenlab.ai/ai-news/exabeam-releases-open-source-praxen-to-verify-ai-agent-behaviour-and-security", "publisher": { "@type": "Organization", "name": "SevenLab" } },
+      { "@type": "NewsArticle", "headline": "Praxen: Open-Source AI Agent Behavior Verification", "url": "https://www.news4hackers.com/praxen-open-source-ai-agent-behavior-verification/", "publisher": { "@type": "Organization", "name": "News4Hackers" } },
+      { "@type": "NewsArticle", "headline": "Praxen featured among 20 open-source cybersecurity tools to keep your team ready", "url": "https://www.helpnetsecurity.com/2026/07/08/20-latest-open-source-cybersecurity-tools/", "publisher": { "@type": "Organization", "name": "Help Net Security" } },
+      { "@type": "NewsArticle", "headline": "Praxen: Open-Source AI Agent Behavior Verification Explained", "url": "https://byteiota.com/praxen-open-source-ai-agent-behavior-verification-explained/", "publisher": { "@type": "Organization", "name": "ByteIota" } },
+      { "@type": "NewsArticle", "headline": "Exabeam Introduces Open Source Tool to Bring Agent Behavior Verification to AI Agents and Digital Workers", "url": "https://www.dbta.com/Editorial/News-Flashes/Exabeam-Introduces-Open-Source-Tool-to-Bring-Agent-Behavior-Verification-to-AI-Agents-and-Digital-Workers-175691.aspx", "publisher": { "@type": "Organization", "name": "Database Trends & Applications" } }
+    ]
+  }
+  </script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://open-agent-ai-security.github.io/praxen/</loc></url>
+  <url><loc>https://open-agent-ai-security.github.io/praxen/news.html</loc></url>
+  <url><loc>https://open-agent-ai-security.github.io/praxen/guide/index.html</loc></url>
+  <url><loc>https://open-agent-ai-security.github.io/praxen/guide/installation.html</loc></url>
+  <url><loc>https://open-agent-ai-security.github.io/praxen/guide/quickstart.html</loc></url>
+  <url><loc>https://open-agent-ai-security.github.io/praxen/guide/usage.html</loc></url>
+  <url><loc>https://open-agent-ai-security.github.io/praxen/guide/writing-remits.html</loc></url>
+  <url><loc>https://open-agent-ai-security.github.io/praxen/guide/interpreting-reports.html</loc></url>
+  <url><loc>https://open-agent-ai-security.github.io/praxen/guide/challenging-findings.html</loc></url>
+  <url><loc>https://open-agent-ai-security.github.io/praxen/guide/understanding-variability.html</loc></url>
+  <url><loc>https://open-agent-ai-security.github.io/praxen/guide/abv.html</loc></url>
+  <url><loc>https://open-agent-ai-security.github.io/praxen/guide/owasp.html</loc></url>
+  <url><loc>https://open-agent-ai-security.github.io/praxen/guide/RAISE.html</loc></url>
+  <url><loc>https://open-agent-ai-security.github.io/praxen/tests/baselines/owasp-coverage-report.html</loc></url>
+  <url><loc>https://open-agent-ai-security.github.io/praxen/tests/baselines/raise-coverage-report.html</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary

Adds SEO/GEO metadata across the GitHub Pages site (`open-agent-ai-security.github.io/praxen/`), mirroring the pattern already applied to Observra (open-agent-ai-security/observra#93):

- **`index.html`**: canonical link, `robots` meta, `keywords` (agent behavior verification, OWASP Top 10 for LLM/Agentic AI Applications, OWASP Gen AI Security, MCP server security, RAISE framework, DevSecOps for AI agents), and a `SoftwareSourceCode` JSON-LD block.
- **`news.html`**: canonical link, `robots` meta, and a `WebPage` + `NewsArticle` `mentions` JSON-LD list matching the 16 press cards already on the page (launch press release + 15 editorial/social mentions).
- **`docs_build.py`**: every generated `guide/*.html` page now gets an auto-derived meta description (from its first `<p>`), canonical URL, Open Graph / Twitter Card tags, and a `TechArticle` JSON-LD block. Deliberately no date fields, same reasoning as Observra's — a git-log-derived date would drift between a full local clone and a shallow CI checkout.
- **`sitemap.xml`** (new): generated by `docs_build.py` from the same `PAGES` list `guide/` already uses, plus the two "📊 See it live" OWASP/RAISE coverage reports that `docs/index.md`, `docs/owasp.md`, and `docs/RAISE.md` all link to prominently. `tests/baselines/suite-health-report.html` was left out — it's a CI-internal health metric, not linked from the docs as public-facing content.
- **`llms.txt`** (new): curated index of Praxen's docs, quickstarts, and live reports for LLM tooling.

Praxen's CI has no `docs-freshness`/lint gate on `docs_build.py` or `guide/` (unlike Observra), so there's no existing check to extend here.

**Out of scope**: a domain-level `robots.txt`/`llms.txt` belongs in the `open-agent-ai-security.github.io` repo (already added in open-agent-ai-security/open-agent-ai-security.github.io#13) — this repo's origin is shared with the observra/praxen project pages, and `robots.txt` is only honored at the origin root.

`guide/*.html` were regenerated locally with `markdown==3.9`, matching the exact version pinned in `requirements-dev.txt` — no version-mismatch risk here.

## Test plan

- [x] All `application/ld+json` blocks validated with `json.loads` (index.html, news.html, guide/index.html, guide/abv.html, guide/owasp.html, guide/RAISE.html)
- [x] `sitemap.xml` validated as well-formed XML
- [x] Confirmed no tests reference `guide/`, `index.html`, or `docs_build.py` output (only unrelated references inside `tests/baselines/`)
- [x] Regenerated with the exact pinned `markdown==3.9`