### PR TITLE
Promote dev → main: SEO consistency cleanup (#185)

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,14 @@
 
   <!-- Social / link-preview cards -->
   <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Praxen">
   <meta property="og:title" content="Praxen — Make sure your agent does its job, and only its job.">
   <meta property="og:description" content="Open-source Agent Behavior Verification. Compare declared intent to real-world evidence and catch behavior drift before it becomes a risk.">
   <meta property="og:url" content="https://open-agent-ai-security.github.io/praxen/">
   <meta property="og:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+  <meta property="og:image:width" content="1280">
+  <meta property="og:image:height" content="640">
+  <meta property="og:image:alt" content="Praxen — open-source Agent Behavior Verification">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Praxen — AI Agent Behavior Verifier">
   <meta name="twitter:description" content="Make sure your agent does its job, and only its job.">
@@ -47,6 +51,7 @@
     "applicationCategory": "SecurityApplication",
     "keywords": "agent behavior verification, AI agent security, OWASP Top 10 for LLM Applications, OWASP Top 10 for Agentic AI Applications, OWASP Gen AI Security, MCP server security, RAISE framework, DevSecOps for AI agents",
     "author": {
+      "@id": "https://open-agent-ai-security.github.io/#org",
       "@type": "Organization",
       "name": "Open Agent and AI Security Community",
       "url": "https://open-agent-ai-security.github.io/"

--- a/news.html
+++ b/news.html
@@ -23,10 +23,14 @@
 
   <!-- Social / link-preview cards -->
   <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Praxen">
   <meta property="og:title" content="Praxen — In the News">
   <meta property="og:description" content="Launch coverage for Praxen, the open-source Agent Behavior Verification platform.">
   <meta property="og:url" content="https://open-agent-ai-security.github.io/praxen/news.html">
   <meta property="og:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">
+  <meta property="og:image:width" content="1280">
+  <meta property="og:image:height" content="640">
+  <meta property="og:image:alt" content="Praxen — In the News">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Praxen — In the News">
   <meta name="twitter:image" content="https://open-agent-ai-security.github.io/praxen/graphics/praxen-social.png">

--- a/tests/baselines/suite-health-report.html
+++ b/tests/baselines/suite-health-report.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, follow">
 <title>Praxen — Baseline Agent Suite Health (Popularity &amp; Freshness)</title>
 <style>@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
 /*
@@ -486,7 +487,7 @@ img { max-width: 100%; display: block; }
   </section>
 
   <footer class="foot">
-    Generated 2026-07-12 · Popularity/freshness snapshot 2026-07-11 · Maturity from the Praxen <code>v1.1-claude48</code> baseline ·
+    Generated 2026-07-14 · Popularity/freshness snapshot 2026-07-11 · Maturity from the Praxen <code>v1.1-claude48</code> baseline ·
     <a href="https://github.com/open-agent-ai-security/praxen" target="_blank" rel="noopener">github.com/open-agent-ai-security/praxen</a>
   </footer>
 </div>

--- a/tests/baselines/suite_health.py
+++ b/tests/baselines/suite_health.py
@@ -212,6 +212,7 @@ def build_html(baseline_dir: Path, out_dir: Path):
     return f"""<!doctype html>
 <html lang="en"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, follow">
 <title>Praxen — Baseline Agent Suite Health (Popularity &amp; Freshness)</title>
 <style>{theme_css}
 {SUITE_CSS}</style>


### PR DESCRIPTION
Promotes the SEO consistency fixes (#185) to the live site: OG parity + author @id + noindex on the internal suite-health report. Docs/marketing-surface only — no code/schema/version change. Cross-reviewed clean alongside the observra + org-pages counterparts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)