### PR TITLE
Harden report timestamp validation and writes

### DIFF
--- a/skills/behavior-verifier/findings.schema.json
+++ b/skills/behavior-verifier/findings.schema.json
@@ -21,7 +21,7 @@
         "agent":           { "type": "string", "minLength": 1 },
         "agent_slug":      { "type": "string", "minLength": 1, "pattern": "^[a-z0-9][a-z0-9-]*$" },
         "scan_date":       { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$" },
-        "scan_timestamp":  { "type": "string", "minLength": 1, "description": "ISO 8601 UTC, e.g. 2026-05-03T04:39:06Z." },
+        "scan_timestamp":  { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$", "description": "ISO 8601 timestamp with explicit timezone, e.g. 2026-05-03T04:39:06Z or 2026-05-03T00:39:06-04:00." },
         "workspace":       { "type": "string", "minLength": 1, "description": "Absolute path to the analyzed workspace." },
         "artifact_count":  { "type": "integer", "minimum": 0 }
       }

--- a/skills/behavior-verifier/render.py
+++ b/skills/behavior-verifier/render.py
@@ -40,6 +40,7 @@ import math
 import os
 import re
 import sys
+import tempfile
 import textwrap
 from datetime import datetime
 
@@ -822,8 +823,20 @@ def render_txt(data: dict) -> str:
 
 # ── I/O ──────────────────────────────────────────────────────────────────────
 def _write(path: str, content: str) -> None:
-    with open(path, "w", encoding="utf-8", newline="\n") as fh:
-        fh.write(content)
+    out_dir = os.path.dirname(os.path.abspath(path)) or "."
+    fd, tmp_path = tempfile.mkstemp(prefix=".praxen-render-", suffix=".tmp", dir=out_dir, text=True)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as fh:
+            fh.write(content)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def _load_json(path: str):
@@ -971,11 +984,17 @@ def main(argv=None) -> int:
             html_out = render_html(_read_template(args.template), data)
         except RenderError as e:
             sys.exit(f"render.py: HTML render error — {e}")
-        _write(args.out_html, html_out)
+        try:
+            _write(args.out_html, html_out)
+        except OSError as e:
+            sys.exit(f"render.py: cannot write HTML report {args.out_html}: {e}")
         print(f"render.py: wrote {args.out_html} ({summary})")
 
     if args.out_txt:
-        _write(args.out_txt, render_txt(data))
+        try:
+            _write(args.out_txt, render_txt(data))
+        except OSError as e:
+            sys.exit(f"render.py: cannot write TXT report {args.out_txt}: {e}")
         print(f"render.py: wrote {args.out_txt} ({summary})")
 
     return 0

--- a/skills/behavior-verifier/schema.py
+++ b/skills/behavior-verifier/schema.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import math
 import re
+from datetime import datetime
 
 # ── version ──────────────────────────────────────────────────────────────────
 # The exact schema version this validator (and the bundled renderer) understands.
@@ -75,6 +76,10 @@ LOG_STATUSES = ["active", "inferred"]
 ESCALATIONS = ["alert", "log_only"]
 
 _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_TIMESTAMP_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"
+    r"(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+)
 # Finding IDs are PRAX-YYYY-MM-DD-NNN — a three-digit sequence, so the
 # implicit ceiling is 999 findings in a single scan. No real target has come
 # close; if one ever does, widen the sequence here and in findings.schema.json.
@@ -208,7 +213,20 @@ def _validate_scan(data):
     sd = _nonempty_str(scan, "scan_date", "$.scan")
     if not _DATE_RE.match(sd):
         _err("$.scan.scan_date", f"must be YYYY-MM-DD; got {sd!r}")
-    _nonempty_str(scan, "scan_timestamp", "$.scan")
+    try:
+        datetime.strptime(sd, "%Y-%m-%d")
+    except ValueError as e:
+        _err("$.scan.scan_date", f"must be a real calendar date; got {sd!r} ({e})")
+    ts = _nonempty_str(scan, "scan_timestamp", "$.scan")
+    if not _TIMESTAMP_RE.match(ts):
+        _err("$.scan.scan_timestamp",
+             f"must be an ISO-8601 timestamp with explicit timezone; got {ts!r}")
+    norm = ts[:-1] + "+00:00" if ts.endswith("Z") else ts
+    try:
+        datetime.fromisoformat(norm)
+    except ValueError as e:
+        _err("$.scan.scan_timestamp",
+             f"must be a real ISO-8601 timestamp with explicit timezone; got {ts!r} ({e})")
     _nonempty_str(scan, "workspace", "$.scan")
     _int(scan, "artifact_count", "$.scan", minimum=0)
 

--- a/tests/render/test_render.py
+++ b/tests/render/test_render.py
@@ -277,6 +277,13 @@ def main():
     out_txt_only = os.path.join(tmp, "only.txt")
     r = run_render(["--findings", FIXTURE, "--out-txt", out_txt_only])
     check("--out-txt without --out-html works", r.returncode == 0 and os.path.exists(out_txt_only))
+    atomic_path = os.path.join(tmp, "atomic.txt")
+    render._write(atomic_path, "first\n")
+    render._write(atomic_path, "second\n")
+    leftovers = [name for name in os.listdir(tmp) if name.startswith(".praxen-render-")]
+    check("report writes replace atomically and clean temporary files",
+          read_text(atomic_path) == "second\n" and not leftovers,
+          f"leftover temp files: {leftovers}")
 
     # 4b. cited code that *looks* like a template placeholder must not corrupt the
     #     render or trip the "unsubstituted placeholder" check.
@@ -528,6 +535,12 @@ def main():
     negative("rejects a legacy bare-list findings file", None)
     negative("rejects a missing required field (behavior_summary)",
              lambda d: d.pop("behavior_summary"))
+    negative("rejects an impossible scan_date even when it matches YYYY-MM-DD",
+             lambda d: d["scan"].__setitem__("scan_date", "2026-02-31"))
+    negative("rejects scan_timestamp without an explicit timezone",
+             lambda d: d["scan"].__setitem__("scan_timestamp", "2026-05-03T04:39:06"))
+    negative("rejects an impossible scan_timestamp even when it matches the ISO shape",
+             lambda d: d["scan"].__setitem__("scan_timestamp", "2026-02-31T04:39:06Z"))
     negative("rejects a footer/severity count mismatch",
              lambda d: d["footer"]["severity_counts"].__setitem__("critical", 99))
     negative("rejects a bad severity enum",


### PR DESCRIPTION
## Summary
- validate scan_date as a real calendar date, not just YYYY-MM-DD shape
- require scan_timestamp to be a real ISO-8601 value with explicit timezone before rendering
- write HTML/TXT reports atomically and surface write failures as CLI diagnostics
- add regression tests for invalid timestamps/dates and atomic report writes

## Validation
- python -m py_compile skills\behavior-verifier\schema.py skills\behavior-verifier\render.py tests\render\test_render.py
- python tests\render\test_plugin_manifests.py
- python tests\render\test_render.py: 418 passed, 32 failed on local Windows checkout; failures are existing byte-identical golden comparisons for rendered artifacts
- python tests\render\test_manifest_to_findings.py: 28 passed, 1 failed on local Windows checkout; failure is existing golden byte comparison