### PR TITLE
fix(render): TXT summary silently deleted route placeholders like <id>

### DIFF
--- a/skills/behavior-verifier/render.py
+++ b/skills/behavior-verifier/render.py
@@ -232,17 +232,29 @@ def render_rich(text, allow=("code",)) -> str:
     return re.sub(r"\x00(\d+)\x00", lambda m: saved[int(m.group(1))], escaped)
 
 
+_STRIPPABLE_TAGS = sorted({t for tags in _RICH_FIELDS.values() for t in tags})
+
+
 def strip_tags(text) -> str:
     """Flatten a rich-text field to plain text for the TXT summary: a ``</p>``
     paragraph break becomes a single space (so sentences don't run together),
-    every other HTML-ish tag (``<p>``, ``<code>``, ``<strong>``, a stray
-    ``<a ...>``, …) is dropped, and HTML entities (``&mdash;``, ``&amp;``,
-    ``&lt;project&gt;`` …) are decoded to their characters — the prose fields
-    legitimately carry entities for the HTML report, and the plain-text summary
-    should show ``—`` / ``&`` / ``<project>`` rather than the raw entity text.
-    A lone ``<`` that is not a tag is left alone."""
+    the other markup tags the prose fields may legitimately carry (``<code>``,
+    ``<strong>``, ``<em>``, ``<p>``) are dropped, and HTML entities
+    (``&mdash;``, ``&amp;``, ``&lt;project&gt;`` …) are decoded to their
+    characters — the prose fields legitimately carry entities for the HTML
+    report, and the plain-text summary should show ``—`` / ``&`` / ``<project>``
+    rather than the raw entity text.
+
+    Only the tags in ``_RICH_FIELDS`` are stripped, deliberately: anything else
+    in angle brackets is content, not markup. Route placeholders are the common
+    case — ``POST /api/vendors/<id>/invoices`` must survive intact, where a
+    generic ``</?[a-zA-Z][^>]*>`` sweep silently ate ``<id>`` and produced
+    ``/api/vendors//invoices``. This also keeps TXT consistent with the HTML
+    report, where ``render_rich`` escapes any tag outside the allow-list into
+    visible text rather than dropping it."""
     t = re.sub(r"\s*</p\s*>\s*", " ", str(text), flags=re.IGNORECASE)
-    t = re.sub(r"</?[a-zA-Z][^>]*>", "", t)
+    tag_alt = "|".join(re.escape(tag) for tag in _STRIPPABLE_TAGS)
+    t = re.sub(rf"</?(?:{tag_alt})\s*>", "", t, flags=re.IGNORECASE)
     return html.unescape(t)
 
 

--- a/tests/fixtures/finbot.golden.txt
+++ b/tests/fixtures/finbot.golden.txt
@@ -205,8 +205,8 @@ HIGH FINDINGS
             limiting; an attacker can iterate prompt-injection payloads or
             denial-of-wallet against the OpenAI quota at line speed.
       Action: Add flask-limiter with per-route caps (e.g. 5/min on /vendors,
-              10/min on /vendors//invoices, 1/min on /admin/finbot/goals). Cap
-              LLM token spend per minute via a budget guard inside
+              10/min on /vendors/<id>/invoices, 1/min on /admin/finbot/goals).
+              Cap LLM token spend per minute via a budget guard inside
               _run_agent_orchestration.
 
   PRAX-2026-05-03-014  No automated test suite, adversarial test fixtures, or


### PR DESCRIPTION
Found by the end-to-end acceptance run (fresh marketplace install → scan of `OWASP-ASI/finbot-ctf-demo`): the plain-text summary recommended hardening **`POST /api/vendors//invoices`** — a route that doesn't exist.

## Cause
`strip_tags()` stripped anything matching `</?[a-zA-Z][^>]*>`, which matches `<id>`, `<vendor_id>`, `<int:invoice_id>` — route placeholders are content, not markup.

Scope, verified:
| Output | Before |
|---|---|
| findings JSON | `/api/vendors/<id>/invoices` ✅ correct |
| HTML report | `/api/vendors/&lt;id&gt;/invoices` ✅ correct |
| **TXT summary** | `/api/vendors//invoices` ❌ **corrupted** |

TXT-only, which is why no schema or byte-render check caught it — and the committed golden had the corrupted form baked in from generation.

## Fix
`strip_tags` now removes only tags the prose fields may legitimately carry (the union of `_RICH_FIELDS`: `p`, `code`, `strong`, `em`). Everything else in angle brackets is left as content — which also aligns TXT with HTML, where `render_rich` escapes non-allowlisted tags into visible text rather than dropping them.

Behaviour checks: route placeholders and `<int:vendor_id>` survive; `<code>`/`<strong>`/`<em>`/`<p>` still stripped; `</p>` still becomes a space; entities still decoded; a lone `<` still untouched.

## Blast radius
- **No baseline change.** No findings JSON is touched; every frozen baseline still re-renders byte-for-byte.
- Golden TXT regenerated — a 2-line diff restoring the placeholder. **Golden HTML byte-identical.**
- Suite **245 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)