### PR TITLE
ci: point Dependabot at dev, not the release channel

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: "/"
+    # Target `dev`, not the default branch. `main` is the release channel and
+    # must stay an ancestor of `dev` (enforced by branch-drift.yml); a PR
+    # merged straight to `main` puts a commit there that `dev` lacks and breaks
+    # that invariant — and the next dev→main promotion inherits the mess.
+    # Without this, Dependabot defaults to the default branch (`main`), which
+    # is how #193 came to target the release channel.
+    target-branch: dev
     schedule:
       interval: weekly
       day: monday


### PR DESCRIPTION
One line of config plus the reasoning.

`.github/dependabot.yml` had no `target-branch`, so Dependabot defaulted to the repo's **default branch — `main`**. That's the release channel: a bump merged there puts a commit on `main` that `dev` doesn't have, which breaks the *main is an ancestor of dev* invariant `branch-drift.yml` enforces and the dev→main promotion relies on.

That's not hypothetical — #193 (`setup-python` 6→7) opened against `main` for exactly this reason and had to be retargeted by hand today, days before the 1.2 promotion.

With `target-branch: dev`, future bumps open against `dev` and reach `main` with the next release, like every other change. Schedule, grouping, labels, and commit prefix are untouched.

No behaviour change to any workflow; config parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)