### PR TITLE
ci(dco): accept sign-off by name when the author email is a GitHub privacy alias

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -90,8 +90,32 @@ jobs:
               const author    = `${c.commit.author.name} <${c.commit.author.email}>`;
               const committer = `${c.commit.committer.name} <${c.commit.committer.email}>`;
               const lines = c.commit.message.split('\n').map(l => l.trim());
-              const signed = lines.includes(`Signed-off-by: ${author}`)
-                          || lines.includes(`Signed-off-by: ${committer}`);
+              let signed = lines.includes(`Signed-off-by: ${author}`)
+                        || lines.includes(`Signed-off-by: ${committer}`);
+
+              // GitHub privacy-alias allowance. When a contributor has email
+              // privacy enabled, GitHub rewrites the AUTHOR email to
+              // `<user>@users.noreply.github.com` — notably when squash-merging
+              // a fork PR — while their own `Signed-off-by` carries the real
+              // address they committed with. The certification is present and
+              // by the same person; only the email FORM differs, and the
+              // contributor cannot fix it after the merge without rewriting
+              // shared history. Accept a name match in exactly that case.
+              // Deliberately narrow: a sign-off trailer must still exist, the
+              // name must match, and this only applies when the author email is
+              // a GitHub noreply alias — never as a general name-only fallback.
+              if (!signed) {
+                const noreply = /@users\.noreply\.github\.com$/i;
+                const eq = (a, b) => a.trim().toLowerCase() === b.trim().toLowerCase();
+                for (const id of [c.commit.author, c.commit.committer]) {
+                  if (!noreply.test(id.email || '')) continue;
+                  const match = lines.some(l => {
+                    const m = l.match(/^Signed-off-by:\s*(.+?)\s*<([^>]+)>$/i);
+                    return m && eq(m[1], id.name);
+                  });
+                  if (match) { signed = true; break; }
+                }
+              }
               if (!signed) {
                 bad.push({ sha: c.sha.slice(0, 12), subject: c.commit.message.split('\n')[0], author });
               }


### PR DESCRIPTION
**Unblocks the 1.2 promotion (#219).** Opening as a PR rather than pushing — this changes a trust control, so it's your call.

## What broke

#219's DCO check fails on exactly one of its 74 non-merge commits:

```
3f2fd7f  Harden report timestamp validation and writes (#194)
  author:    Christopher Deck <christopherdeck@users.noreply.github.com>
  sign-off:  Signed-off-by: Christopher Deck <christopherdeck@gmail.com>
```

Same human, different email **form**. When a contributor has GitHub email privacy enabled, GitHub rewrites the author email to the `@users.noreply.github.com` alias — which is what happened when Christopher's fork PR was squash-merged — while his sign-off carries the address he actually committed with. Our check demands an exact `name <email>` match, so it fails.

It passed on #194 itself (his original commits matched), and surfaces only now because the promotion PR is the first to include the squash commit in a DCO-checked list. **It would have blocked Monday either way** — opening #219 early is what caught it.

It also isn't a one-off: it will recur for any fork contributor with email privacy on, which is a common default. Getting more outside contributors is a project goal, so this is worth fixing properly rather than working around.

## The change

If (and only if) the author or committer email is a GitHub noreply alias, accept a `Signed-off-by` whose **name** matches. Deliberately narrow — verified by test:

| case | result |
|---|---|
| Christopher's squash (the failure) | ✅ passes |
| normal exact match | ✅ passes |
| noreply author, **no sign-off at all** | ❌ still fails |
| noreply author, sign-off naming **someone else** | ❌ still fails |
| normal author, **wrong email** in sign-off | ❌ still fails |
| malformed trailer (no angle brackets) | ❌ still fails |
| `id+login@users.noreply.github.com` form | ✅ passes |
| case-insensitive name | ✅ passes |

YAML and the embedded JS both parse (`node --check`).

## Alternatives considered

- **Admin-merge past the red check** — works, but leaves a permanently red DCO on the most visible PR in the project's history and sets a bypass precedent on a security project.
- **Rewrite `dev` to re-sign the commit** — force-pushing a shared branch, ~20 rewritten SHAs, and it would alter a contributor's commit. Rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)