### PR TITLE
ci(dco): accept sign-off by name when the author email is a GitHub privacy alias

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -4,7 +4,7 @@
 # Enforces the Developer Certificate of Origin (see CONTRIBUTING.md): every
 # non-merge, non-bot commit in a pull request must carry a `Signed-off-by:`
 # trailer whose name/email matches the commit's author or committer. GitHub
-# bot accounts (Dependabot, gemini-code-assist, …) are exempt.
+# bot accounts (e.g. Dependabot) are exempt.
 #
 # Runs on `pull_request_target` (not `pull_request`) on purpose:
 #   - it fires IMMEDIATELY, even for first-time fork contributors (whose
@@ -81,15 +81,41 @@ jobs:
             const bad = [];
             for (const c of commits) {
               if (c.parents.length > 1) continue;                       // merge commit — exempt
+              // Bot exemption keys ONLY on the GitHub-resolved account type —
+              // never on the commit's author name, which is contributor-
+              // controlled (`git -c user.name="x[bot]"` must not skip DCO, #209).
               const ghIsBot = c.author && c.author.type === 'Bot';
-              const nameIsBot = /\[bot\]$/.test(c.commit.author.name);
-              if (ghIsBot || nameIsBot) continue;                       // bot account — exempt
+              if (ghIsBot) continue;                                    // bot account — exempt
 
               const author    = `${c.commit.author.name} <${c.commit.author.email}>`;
               const committer = `${c.commit.committer.name} <${c.commit.committer.email}>`;
               const lines = c.commit.message.split('\n').map(l => l.trim());
-              const signed = lines.includes(`Signed-off-by: ${author}`)
-                          || lines.includes(`Signed-off-by: ${committer}`);
+              let signed = lines.includes(`Signed-off-by: ${author}`)
+                        || lines.includes(`Signed-off-by: ${committer}`);
+
+              // GitHub privacy-alias allowance. When a contributor has email
+              // privacy enabled, GitHub rewrites the AUTHOR email to
+              // `<user>@users.noreply.github.com` — notably when squash-merging
+              // a fork PR — while their own `Signed-off-by` carries the real
+              // address they committed with. The certification is present and
+              // by the same person; only the email FORM differs, and the
+              // contributor cannot fix it after the merge without rewriting
+              // shared history. Accept a name match in exactly that case.
+              // Deliberately narrow: a sign-off trailer must still exist, the
+              // name must match, and this only applies when the author email is
+              // a GitHub noreply alias — never as a general name-only fallback.
+              if (!signed) {
+                const noreply = /@users\.noreply\.github\.com$/i;
+                const eq = (a, b) => a.trim().toLowerCase() === b.trim().toLowerCase();
+                for (const id of [c.commit.author, c.commit.committer]) {
+                  if (!noreply.test(id.email || '')) continue;
+                  const match = lines.some(l => {
+                    const m = l.match(/^Signed-off-by:\s*(.+?)\s*<([^>]+)>$/i);
+                    return m && eq(m[1], id.name);
+                  });
+                  if (match) { signed = true; break; }
+                }
+              }
               if (!signed) {
                 bad.push({ sha: c.sha.slice(0, 12), subject: c.commit.message.split('\n')[0], author });
               }


### PR DESCRIPTION
**Unblocks the 1.2 promotion (#219).** One file, `.github/workflows/dco.yml`.

Targets `main` directly on purpose: `pull_request_target` workflows run the definition from the PR's **base** branch, so #219's DCO check reads *main's* copy — a dev-only fix wouldn't unblock it. (`main` and `dev` have already diverged on this file; the #209 hardening landed on dev and never reached main.)

## The failure

#219 fails on exactly one of its 74 non-merge commits:

```
3f2fd7f  Harden report timestamp validation and writes (#194)
  author:    Christopher Deck <christopherdeck@users.noreply.github.com>
  sign-off:  Signed-off-by: Christopher Deck <christopherdeck@gmail.com>
```

Same person, different email **form**. With GitHub email privacy enabled, GitHub rewrites the author email to the noreply alias when squash-merging a fork PR, while the sign-off keeps the real address. It passed on #194 itself and surfaces only now, because the promotion PR is the first to include the squash commit in a checked list — and after the squash the contributor cannot fix it without rewriting shared history.

Not a one-off: it recurs for any fork contributor with email privacy on, a common default.

## The change

If (and only if) the author or committer email is a GitHub noreply alias, accept a `Signed-off-by` whose **name** matches. Verified:

| case | result |
|---|---|
| Christopher's squash (the failure) | ✅ passes |
| normal exact match | ✅ passes |
| noreply author, **no sign-off at all** | ❌ still fails |
| noreply author, sign-off naming **someone else** | ❌ still fails |
| normal author, **wrong email** in sign-off | ❌ still fails |
| malformed trailer | ❌ still fails |
| `id+login@…` noreply form · case-insensitive name | ✅ pass |

**Also brings main the #209 hardening it never received:** the bot exemption now keys only on the GitHub-resolved account type, not the contributor-controlled commit author name — so `git -c user.name="x[bot]"` can no longer skip DCO. Main has been missing that since it was fixed on dev.

YAML and the embedded JS both parse (`node --check`).

## After merge
1. Re-run #219's DCO check → expect green
2. Sync `dev` with `main` so the *main is an ancestor of dev* invariant is restored before Monday

🤖 Generated with [Claude Code](https://claude.com/claude-code)