### PR TITLE
content(news): add the community blog's 'When a Security Scan Earns Its Keep'

### DIFF
--- a/news.html
+++ b/news.html
@@ -56,6 +56,7 @@
       "url": "https://www.exabeam.com/"
     },
     "mentions": [
+      { "@type": "NewsArticle", "headline": "When a Security Scan Earns Its Keep", "url": "https://open-agent-ai-security.github.io/blog/praxen-scan-earns-keep/", "publisher": { "@type": "Organization", "name": "Open Agent AI Security" } },
       { "@type": "NewsArticle", "headline": "Praxen 1.2: OWASP 2026 coverage, a next-generation engine, and independently-verified accuracy", "url": "https://open-agent-ai-security.github.io/blog/praxen-1-2-release/", "publisher": { "@type": "Organization", "name": "Open Agent AI Security" } },
       { "@type": "NewsArticle", "headline": "Exabeam Launches Open-Source Praxen to Bring Agent Behavior Verification to AI Agents and Digital Workers", "url": "https://www.exabeam.com/press-releases/exabeam-launches-open-source-praxen-to-bring-agent-behavior-verification-to-ai-agents-and-digital-workers/", "publisher": { "@type": "Organization", "name": "Exabeam" } },
       { "@type": "NewsArticle", "headline": "Exabeam launches Praxen, an open-source tool to verify AI agent behavior", "url": "https://siliconangle.com/2026/06/23/exabeam-launches-praxen-open-source-tool-verify-ai-agent-behavior/", "publisher": { "@type": "Organization", "name": "SiliconANGLE" } },
@@ -327,6 +328,11 @@
       <div class="wrap">
         <h2>Industry commentary</h2>
         <div class="cov-grid">
+          <a class="cov-card" href="https://open-agent-ai-security.github.io/blog/praxen-scan-earns-keep/" target="_blank" rel="noopener">
+            <div class="cov-outlet">Open Agent AI Security · Community Blog</div>
+            <p class="cov-title">When a Security Scan Earns Its Keep — a developer ran Praxen against a security-sensitive agent codebase: a data-exposure gap in diagnostic exports, unsafe tool descriptions, and unescaped third-party text in a privileged instruction channel, all found and fixed the same day</p>
+            <span class="cov-read">Read →</span>
+          </a>
           <a class="cov-card" href="https://prompt-to-patch-vinaya.hashnode.dev/what-praxen-found-on-finbot-and-where-sailors-fits" target="_blank" rel="noopener">
             <div class="cov-outlet">Vinaya Vasu · Hashnode</div>
             <p class="cov-title">What Praxen Found on FinBot and Where SAILORS Fits — a walkthrough of Praxen's FinBot findings, showing how design-time (SAILORS) and implementation-time (Praxen) checks catch the same gaps</p>


### PR DESCRIPTION
Adds one card to **Industry commentary** on `news.html`, leading the grid:

> **Open Agent AI Security · Community Blog**
> When a Security Scan Earns Its Keep — a developer ran Praxen against a security-sensitive agent codebase: a data-exposure gap in diagnostic exports, unsafe tool descriptions, and unescaped third-party text in a privileged instruction channel, all found and fixed the same day

Links [the post](https://open-agent-ai-security.github.io/blog/praxen-scan-earns-keep/) (2026-08-02).

**Attribution note:** the developer requested anonymity, so the card credits the community blog rather than a person. This is also the one commentary entry with no external original — the Hashnode and LinkedIn cards link their source, but this story exists only as our post.

Also adds the matching JSON-LD `mentions` entry, consistent with the other `open-agent-ai-security.github.io` posts already listed there (coverage in that block is partial across the page; our own blog posts are represented).

## Checks
- JSON-LD parses — 19 mentions, new entry first
- Card leads the Industry commentary grid (12 cards); outlet label renders as expected
- HTML tag balance unchanged
- Target URL returns **200**

🤖 Generated with [Claude Code](https://claude.com/claude-code)