### PR TITLE
docs: correct stale schema version, support policy, and a dead OWASP link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,10 +55,11 @@ If you do not hear back from us within the windows above, please nudge the threa
 
 ## Supported versions
 
-Security fixes ship in the **latest** released `0.x` line. Praxen is pre-`1.0` and there is no LTS branch; please upgrade to the latest tagged release before reporting.
+Security fixes ship in the **latest** released `1.x` line. There is no LTS branch and no back-porting to earlier minors; please upgrade to the latest tagged release before reporting.
 
 | Version | Receiving security fixes |
 |---|---|
 | **Latest tagged release** | ✓ Yes — always upgrade to the newest release before reporting |
-| Anything older than the latest release | No — no back-porting while pre-`1.0`; no LTS branch yet |
+| Anything older than the latest release | No — no back-porting to earlier minors; no LTS branch |
+| `0.x` (pre-`1.0`) | No — superseded, not maintained |
 | `0.6.x` and earlier (under the former name `Praxa`, at `Exabeam/deckard`) | No — superseded by the rename, not maintained |

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -5,7 +5,7 @@
 
 # Praxen Stability Contract
 
-From **1.0**, Praxen follows semantic versioning across two independently-versioned surfaces — the **product version** (`praxen_version`, e.g. `1.0.0`) and the **findings-schema version** (`schema_version`, currently `2.0`). This document defines what each major line guarantees. **Anything not listed as Stable is explicitly Evolving and may change in a minor release.**
+From **1.0**, Praxen follows semantic versioning across two independently-versioned surfaces — the **product version** (`praxen_version`, e.g. `1.0.0`) and the **findings-schema version** (`schema_version`, currently `3.0`). This document defines what each major line guarantees. **Anything not listed as Stable is explicitly Evolving and may change in a minor release.**
 
 ## Semver / compatibility policy
 
@@ -23,7 +23,7 @@ Within a given `schema_version` MAJOR, the published JSON is a stable contract f
 - The **required sections**: `scan`, `intro_band`, `behavior_summary`, `remit_coverage`, `findings`, `positives`, `log_files`, `raise_posture`, `footer`.
 - The **fixed enumerations**: `SEVERITIES`, `REMIT_STATUSES`, `CONFIDENCES`, `TAG_KINDS`, `ESCALATIONS`, and the finding-ID grammar `PRAX-YYYY-MM-DD-NNN`.
 
-**Strict today; additive by policy.** The published schema and the bundled validator (`schema.py`) are **strict** to the current `schema_version` (`2.0`): objects are closed (`additionalProperties: false`) and enums are fixed, so they validate Praxen's own output exactly and reject anything they don't recognize. The **compatibility policy** for future minors is additive — a new *optional* field or enum *value* may ship in a schema MINOR (e.g. `2.1`), and when one does, the published schema and validator are updated in lockstep to accept it. Removing a field, removing/renaming an enum value, or changing a type or required-ness is a schema-MAJOR (`3.0`) change. **Downstream consumers** should pin to the schema MAJOR and tolerate fields/values they don't recognize *in their own parsing*; Praxen's strict validator exists to check Praxen's output, not to read a future minor.
+**Strict today; additive by policy.** The published schema and the bundled validator (`schema.py`) are **strict** to the current `schema_version` (`3.0`): objects are closed (`additionalProperties: false`) and enums are fixed, so they validate Praxen's own output exactly and reject anything they don't recognize. The **compatibility policy** for future minors is additive — a new *optional* field or enum *value* may ship in a schema MINOR (e.g. `3.1`), and when one does, the published schema and validator are updated in lockstep to accept it. Removing a field, removing/renaming an enum value, or changing a type or required-ness is a schema-MAJOR (`4.0`) change — as `3.0` itself was, in Praxen 1.2, when `policy_rule_ids` / `policy_rule_text` became required arrays. **Downstream consumers** should pin to the schema MAJOR and tolerate fields/values they don't recognize *in their own parsing*; Praxen's strict validator exists to check Praxen's output, not to read a future minor.
 
 ### 2. The RAISE six-category set and weights
 

--- a/docs/interpreting-reports.md
+++ b/docs/interpreting-reports.md
@@ -153,7 +153,7 @@ Low confidence is valid and expected when the input shape doesn't cover a catego
 
 | Key | What's in it |
 |---|---|
-| `schema_version`, `praxen_version` | `"2.0"` and the Praxen version that produced the file |
+| `schema_version`, `praxen_version` | `"3.0"` and the Praxen version that produced the file |
 | `scan` | agent name and slug, scan date and timestamp, the analyzed workspace path, artifact count |
 | `intro_band` | the two short prose summaries — `agent_remit_summary`, `agent_structure_summary` |
 | `behavior_summary` | the dominant-pattern narrative (same text as the report's Behavior Summary section) |

--- a/docs/owasp.md
+++ b/docs/owasp.md
@@ -20,7 +20,7 @@ As LLM-based systems moved into production, OWASP spun up a dedicated effort: th
 | Document | What it covers | Praxen tag prefix |
 |---|---|---|
 | [OWASP Top 10 for LLM Applications 2026](https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/tree/main/2026/final) | Risks in applications built on large language models | `LLM01`–`LLM10` |
-| [OWASP Top 10 for Agentic AI Applications 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-ai-applications/) | Risks specific to autonomous, tool-using agents | `ASI01`–`ASI10` |
+| [OWASP Top 10 for Agentic AI Applications 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) | Risks specific to autonomous, tool-using agents | `ASI01`–`ASI10` |
 | [A Practical Guide for Secure MCP Server Development 2026](https://genai.owasp.org/resource/a-practical-guide-for-secure-mcp-server-development/) | Securing Model Context Protocol servers and the tools they expose | `mcp` (checklist items) |
 
 Praxen carries distilled extracts of all three in its knowledge base (`skills/behavior-verifier/knowledge/`), but the canonical, full-length versions live at the links above — go there for the complete write-ups, examples, and references.
@@ -78,7 +78,7 @@ Risks that emerge once an LLM is wired to tools, memory, other agents, and the a
 | <a id="asi09"></a>**ASI09** | Human-Agent Trust Exploitation | The agent's perceived authority is used to manipulate the humans who rely on it (or vice versa). |
 | <a id="asi10"></a>**ASI10** | Rogue Agents | An agent operates outside its remit — compromised, misconfigured, or deliberately planted. |
 
-→ Full document: **[OWASP Top 10 for Agentic AI Applications 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-ai-applications/)**
+→ Full document: **[OWASP Top 10 for Agentic AI Applications 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/)**
 
 ## A Practical Guide for Secure MCP Server Development 2026
 

--- a/guide/interpreting-reports.html
+++ b/guide/interpreting-reports.html
@@ -438,7 +438,7 @@ img { max-width: 100%; display: block; }
 <tbody>
 <tr>
 <td><code>schema_version</code>, <code>praxen_version</code></td>
-<td><code>"2.0"</code> and the Praxen version that produced the file</td>
+<td><code>"3.0"</code> and the Praxen version that produced the file</td>
 </tr>
 <tr>
 <td><code>scan</code></td>

--- a/guide/owasp.html
+++ b/guide/owasp.html
@@ -299,7 +299,7 @@ img { max-width: 100%; display: block; }
 <td><code>LLM01</code>–<code>LLM10</code></td>
 </tr>
 <tr>
-<td><a href="https://genai.owasp.org/resource/owasp-top-10-for-agentic-ai-applications/">OWASP Top 10 for Agentic AI Applications 2026</a></td>
+<td><a href="https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/">OWASP Top 10 for Agentic AI Applications 2026</a></td>
 <td>Risks specific to autonomous, tool-using agents</td>
 <td><code>ASI01</code>–<code>ASI10</code></td>
 </tr>
@@ -501,7 +501,7 @@ img { max-width: 100%; display: block; }
 </tr>
 </tbody>
 </table>
-<p>→ Full document: <strong><a href="https://genai.owasp.org/resource/owasp-top-10-for-agentic-ai-applications/">OWASP Top 10 for Agentic AI Applications 2026</a></strong></p>
+<p>→ Full document: <strong><a href="https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/">OWASP Top 10 for Agentic AI Applications 2026</a></strong></p>
 <h2 id="a-practical-guide-for-secure-mcp-server-development-2026">A Practical Guide for Secure MCP Server Development 2026</h2>
 <p>The Model Context Protocol (MCP) is how many agents discover and call external tools. MCP servers are unusual: they run with delegated user permissions, support dynamic tool loading, and can chain tool calls — so a single weakness amplifies. When Praxen finds an MCP configuration in the evidence (<code>.mcp.json</code>, <code>mcp.json</code>, or similar), it applies the guide's <strong>minimum-bar checklist</strong> across these areas:</p>
 <ul>


### PR DESCRIPTION
Fixes items 1, 2 and 4 from the post-release docs review (#225, #226). Documentation only — **no scan, render, or baseline artifact is touched** (verified: zero changed files under `tests/baselines/`, `examples/`, `tests/fixtures/`, `skills/`).

## 1. `STABILITY.md` — the contract stated the wrong schema major

It said `schema_version` was "currently `2.0`" and used `3.0` as a *hypothetical* example of a future major bump. **3.0 shipped in 1.2 today.** An integrator following the published contract would pin the wrong major and have every 1.2 report rejected by their own validator.

Now states `3.0`, shifts the examples up (`3.1` minor / `4.0` major), and notes that `3.0` *was* the 1.2 bump — `policy_rule_ids` / `policy_rule_text` becoming required arrays.

## 2. `docs/interpreting-reports.md:156` — same error in the JSON field table

Told readers to expect `"2.0"`. Now `"3.0"`.

## 3. `SECURITY.md` — support policy still said pre-1.0

Declared "Praxen is pre-`1.0`" and scoped fixes to the "`0.x` line", two minor releases after 1.0. Someone reporting a vulnerability read a policy that doesn't describe the project. Now scoped to the `1.x` line, with `0.x` listed explicitly as superseded and unmaintained.

## 4. `docs/owasp.md` — dead OWASP link (both occurrences)

`…/resource/owasp-top-10-for-agentic-ai-applications/` returns **404**. Repointed to the canonical `…/resource/owasp-top-10-for-agentic-applications-for-2026/` — found by following the site's own redirect, and verified **200 directly** rather than relying on the redirect. Worth fixing promptly given the release leads on OWASP alignment.

## Verification
- `./build.sh` green; suite **245 / 0**
- `guide/` regenerated for the two `docs/` files (docs-freshness gate) — the only generated output affected
- **All five** `genai.owasp.org` links across the docs return 200
- Zero scan/render/baseline artifacts changed

Not included: #227 (report tag chips → unstyled Jekyll `/docs/`), deliberately deferred — it requires regenerating 85 committed renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)