### PR TITLE
plans: close out 1.2 as shipped; draft the 1.2.1 fast-follow

### DIFF
--- a/plans/RELEASE_1.2.1_PLAN.md
+++ b/plans/RELEASE_1.2.1_PLAN.md
@@ -1,0 +1,141 @@
+<!--
+  Copyright 2026 Exabeam, Inc.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Praxen 1.2.1 — Fast-follow patch (docs, CI, packaging)
+
+> ## ▶ STATUS: DRAFT — proposed 2026-08-03, not yet approved
+>
+> Drafted immediately after the `v1.2.0` release from the promotion and
+> post-release reviews. **Everything here is deliberately score-inert**: no
+> item changes detection, scoring, remits, or any frozen findings JSON, so
+> **1.2.1 ships against the existing `v1.2-opus5` baseline with no re-scan and
+> no re-freeze.** That is the entry criterion — an item that moves a number
+> belongs in 1.3, not here.
+
+## Why a patch release at all
+
+1.2.0 shipped clean, and the post-release scan check was green. But the reviews
+that ran *during* the promotion surfaced a cluster of small factual and
+plumbing defects that are cheap to fix and awkward to leave standing — chiefly
+**normative documents stating the wrong contract** and **CI trust checks that
+are looser than intended**. None warranted holding the release; together they
+warrant a patch rather than waiting for 1.3.
+
+The four highest-value corrections (schema version in `STABILITY.md` and the
+reports reference, the pre-`1.0` support policy, the dead OWASP link) **already
+shipped to `main` on 2026-08-03** and are live. What remains is the tail.
+
+## Entry criteria (the test every item must pass)
+
+1. **No findings JSON is touched.** No re-scan, no re-freeze, no band change.
+2. **No change to scoring, detection, or remit content.**
+3. **No schema change** — `schema_version` stays `3.0`.
+4. Bounded and reviewable in a single sitting; a mechanical diff wherever
+   possible.
+
+Item 5 below is the one that regenerates committed HTML. It still passes the
+test — no JSON, no scores — but it is called out separately because the diff is
+large, and it is optional for this release.
+
+## Scope
+
+### A · Documentation corrections *(the remainder of #225 / #226)*
+
+- **`tests/README.md` self-contradiction** — line 17 says baselines are
+  "schema-2.0" two lines after line 15 correctly describes the v1.2 set as
+  schema 3.0. Also `tests/README.md:244`, which points the release-review step
+  at the **archival** `v1.1-claude48` set rather than `v1.2-opus5`.
+- **Install confirm lines still say `v1.0.0+`**, and there is no "upgrading from
+  1.1" guidance anywhere — the audience most likely to read the docs right now.
+- **Scan-to-scan diff is shipped but undocumented** outside the CHANGELOG
+  (`tests/scan_diff.py`). It is a headline-adjacent 1.2 feature that a user
+  cannot discover.
+- **Broken `render_remit.py` invocation** in the docs (per #225).
+- **#224 — `SKILL.md` Step 9.9**: the `--validate-manifest` example is
+  unrunnable (`--manifest <path>` is required and `--validate-manifest` is a
+  flag), and the skeleton-tolerance wording overstates the case — the validator
+  tolerates *absent* sections but correctly rejects a present-but-empty
+  `remit_coverage.rules`.
+
+### B · CI and supply-chain hygiene *(no product surface)*
+
+- **#222 — DCO bot exemption** keys on the email-derived `c.author.type === 'Bot'`
+  rather than an explicit login allowlist. Tighten to the bots that actually
+  open PRs here (Dependabot).
+- **#209 item 2 — dependabot auto-merge** merges immediately when the base
+  branch has no required checks. Gate it.
+- **#209 item 3 — SHA-pin GitHub Actions** rather than floating major tags.
+  Dependabot (now correctly targeting `dev`) keeps them current.
+
+### C · Optional / needs a call
+
+- **#227 — report tag chips link the unstyled Jekyll `/docs/` render** instead of
+  the styled `/guide/` pages. Score-inert, but fixing it regenerates **85
+  committed HTML renders** (baselines, examples, the golden fixture) because the
+  byte-render gate requires committed renders to reproduce exactly. Every diff
+  should be *only* the URL substitution — mechanically verifiable.
+  **Do not "fix" this with `.nojekyll`**: that turns `/praxen/docs/` into a 404
+  and breaks every report users have already generated and shared at 1.0/1.1/1.2,
+  which we cannot reach. Include only if the 85-file diff is acceptable in a
+  patch; otherwise 1.3.
+- **#216 — `SKILL.md` §9.2's worked example describes FinBot verbatim**, including
+  a real finding on a roster/demo target. The fix is prose-only, but it is prose
+  the scanning model reads while authoring `agent_structure_summary`, so it is
+  the one item here with a non-zero (small) chance of nudging output style.
+  If included, pair it with a single spot-check scan before merge.
+- **#151 — Google Antigravity (`agy`) harness**: packaging and docs only, engine
+  unchanged; an external contact is waiting and the 1.3 plan already notes there
+  is no engineering reason to hold it. Additive, but it does open a new support
+  surface — a scope call, not a technical risk.
+- **#106 — clarify Out-of-Scope remit coverage** as boundary-rule checks.
+  Authoring-side guidance; no scan-behavior change against committed remits.
+
+## Explicitly NOT in 1.2.1
+
+Each of these moves a number, changes the schema contract, or is a feature —
+all belong to 1.3 (`RELEASE_1.3_PLAN.md`):
+
+| Item | Why not |
+|---|---|
+| #48 scoring rework | The 1.3 headline; re-baseline by definition |
+| #198 / #200 / #201 remit work | Remit changes move scores; needs a re-freeze |
+| #195 band anchors · #196 decomposition rule | Scoring/variance surface |
+| #173 / #174 tagging calibration | Changes frozen tags |
+| #41 · #104 detection additions | New findings |
+| #70 roster gap | New target = re-baseline |
+| #176 suite_health full 0–5 scale | Explicitly gated on the next re-baseline |
+| #113 `<code>` wrapping in prose fields | **Model-output change** — moves every committed render and is a prose-behavior change |
+| #27 finding collapse/expand | Report UX feature, not a patch fix |
+| #197 Thinking Modes | User-facing feature |
+| #117 / #118 operator override + revision records | Schema-contract change |
+| #217 manifest-authoring fragility | Architectural; needs design |
+| #90 design system · #135 docs simplicity pass | Larger efforts |
+
+## Success criteria
+
+- Suite stays **245 / 0**; `./build.sh` green; mirror check in sync.
+- `tests/baselines/` byte-identical **unless C/#227 is included**, in which case
+  every changed file's diff is the URL substitution and nothing else.
+- No `schema_version` change; `CURRENT` still `v1.2-opus5`.
+- A fresh marketplace install of 1.2.1 scans one baseline target and lands
+  within band — the same check that validated 1.2.0.
+
+## Sequencing
+
+A and B are independent and can land in one PR each. Decide C before starting:
+if #227 is in, land it **last and alone**, so the 85-file regeneration is
+reviewable on its own rather than mixed with prose edits.
+
+Version bump is `1.2.0 → 1.2.1` by hand across `PRAXEN_SPEC.md`,
+`.claude-plugin/plugin.json`, the praxen entry in
+`.claude-plugin/marketplace.json`, and `.codex-plugin/plugin.json` — praxen has
+no bump script; `build.sh`'s four-way guard is what enforces agreement (it now
+looks the marketplace entry up **by name**, so the mirror's extra entries are
+safe). Then the CHANGELOG entry, the usual `dev` → `main` merge-commit
+promotion, fast-forward `dev`, and tag.
+
+**Remember what "released" means now:** the community catalog pins praxen's
+`main`, so **merging the promotion is what ships to users** — the tag only cuts
+the zip and the GitHub release. Sequence any announcement accordingly.

--- a/plans/RELEASE_1.2.1_PLAN.md
+++ b/plans/RELEASE_1.2.1_PLAN.md
@@ -140,6 +140,12 @@ large, and it is optional for this release.
   the mechanism-vs-property note in the remit template. Author-side only; the
   committed remits 1.2.1 scores against are unchanged, so this is inert for the
   frozen set.
+- **#176 item 3 leftover** *(ride-along only)*: `rows_table` in
+  `tests/baselines/suite_health.py` reaches for the `DEFAULT_BASELINE` module
+  global at lines 121 and 131 rather than the resolved `baseline_dir`, so
+  `--baseline-dir` isn't honored for the report-link and remit columns. Roughly
+  two lines. Take it **only** if someone is already in that file — it does not
+  justify its own PR, and the rest of #176 stays gated on the re-baseline.
 
   ⚠️ **#65 item 8 is NOT in scope, contra the 1.3 plan's note.** That item puts
   absence-of-evidence confidence calibration into `KB_RAISE_SCANNING.md` — which
@@ -171,7 +177,7 @@ above is here with its reason.
 | #117 / #118 operator override + revision records | Schema-contract change |
 | #217 manifest-authoring fragility | Architectural; needs design |
 | #25 SKILL.md rendering/MVC split | Restructures the file the model reads — too structural for a patch, even as a pure refactor |
-| #176 suite_health full 0–5 scale | Gated on the next re-baseline by its own title. *Worth re-examining* — it looks like presentation over frozen data, so the gate may be conservative; decide deliberately rather than by inheritance |
+| #176 suite_health axis/labels | **Re-examined 2026-08-03 — the gate is correct, not inherited.** Items 1–2 are decisions about how to display a score distribution, and can't be made until that distribution changes (the 1.3 re-freeze). Both are latent today: roster max is hermes **2.55**, 0.45 clear of the 3.0 cap, so nothing clips or mislabels. Item 3's main half already shipped in 1.2 (`DEFAULT_BASELINE` now reads `CURRENT`). Issue retitled — the old title said "full 0–5 scale", which its own body argues *against* |
 | #151 Antigravity harness | **Held (Steve, 2026-08-03)** — additive packaging, but it opens a new supported harness. New surface, not a cleanup |
 | #90 org design system · #2 standing config | Larger efforts; #2 explicitly deferred long-standing |
 

--- a/plans/RELEASE_1.2.1_PLAN.md
+++ b/plans/RELEASE_1.2.1_PLAN.md
@@ -68,6 +68,35 @@ large, and it is optional for this release.
   branch has no required checks. Gate it.
 - **#209 item 3 — SHA-pin GitHub Actions** rather than floating major tags.
   Dependabot (now correctly targeting `dev`) keeps them current.
+- **`scripts/bump_version.py`** *(new — Steve, 2026-08-03)*. Praxen keeps the
+  version in **five** places and edits every one of them by hand:
+
+  | Surface | Guarded by |
+  |---|---|
+  | `PRAXEN_SPEC.md` (`**Version:**`) | `build.sh` (the authority the tag is checked against) |
+  | `.claude-plugin/plugin.json` | `build.sh` + `test_plugin_manifests.py` |
+  | `.claude-plugin/marketplace.json` (praxen entry, **by name**) | as above |
+  | `.codex-plugin/plugin.json` | as above |
+  | `README.md` release badge | `test_plugin_manifests.py` only — **not** `build.sh` |
+
+  The guards catch drift, but only *after* someone has already shipped a
+  half-edited bump into a PR — and the release cadence means a bump is usually
+  cut under time pressure. A script makes the bump one command and the guards a
+  backstop rather than the discovery mechanism.
+
+  **socxen already has one** (`scripts/bump_version.py`) and it is good prior
+  art — same shape: edit, regenerate derived artifacts, verify all surfaces
+  agree, print the diff, do **not** commit. Port it rather than reinvent, with
+  two lessons from socxen's own history: (a) it must look the marketplace entry
+  up **by name**, never positionally — praxen's mirror carries a socxen entry
+  too, and the positional read was a live latent bug fixed in #214; (b) when a
+  surface is removed, the *verify* block must be updated with the edit block —
+  socxen's crashed after writing its edits because a stale reference survived in
+  verification only.
+
+  Scope note: praxen has no AI-BOM to regenerate (socxen's script does that);
+  praxen's derived step is `guide/` via `docs_build.py` only if a bumped version
+  appears in `docs/`, which today it does not.
 
 ### C · Optional / needs a call
 
@@ -128,12 +157,14 @@ A and B are independent and can land in one PR each. Decide C before starting:
 if #227 is in, land it **last and alone**, so the 85-file regeneration is
 reviewable on its own rather than mixed with prose edits.
 
-Version bump is `1.2.0 → 1.2.1` by hand across `PRAXEN_SPEC.md`,
-`.claude-plugin/plugin.json`, the praxen entry in
-`.claude-plugin/marketplace.json`, and `.codex-plugin/plugin.json` — praxen has
-no bump script; `build.sh`'s four-way guard is what enforces agreement (it now
-looks the marketplace entry up **by name**, so the mirror's extra entries are
-safe). Then the CHANGELOG entry, the usual `dev` → `main` merge-commit
+Version bump is `1.2.0 → 1.2.1` across the five surfaces listed in **B**.
+`build.sh`'s four-way guard enforces agreement on all but the README badge (it
+now looks the marketplace entry up **by name**, so the mirror's extra entries
+are safe); `test_plugin_manifests.py` covers the badge.
+
+**Land `scripts/bump_version.py` early in the release, then use it to cut this
+release's own bump** — that is both the fastest way to validate it and the most
+honest test. Then the CHANGELOG entry, the usual `dev` → `main` merge-commit
 promotion, fast-forward `dev`, and tag.
 
 **Remember what "released" means now:** the community catalog pins praxen's

--- a/plans/RELEASE_1.2.1_PLAN.md
+++ b/plans/RELEASE_1.2.1_PLAN.md
@@ -98,33 +98,63 @@ large, and it is optional for this release.
   praxen's derived step is `guide/` via `docs_build.py` only if a bumped version
   appears in `docs/`, which today it does not.
 
-### C · Optional / needs a call
+### C · Report and authoring clean-ups *(approved for scope — Steve, 2026-08-03)*
 
 - **#227 — report tag chips link the unstyled Jekyll `/docs/` render** instead of
   the styled `/guide/` pages. Score-inert, but fixing it regenerates **85
   committed HTML renders** (baselines, examples, the golden fixture) because the
   byte-render gate requires committed renders to reproduce exactly. Every diff
-  should be *only* the URL substitution — mechanically verifiable.
+  must be *only* the URL substitution — mechanically verifiable, and worth
+  verifying rather than trusting.
   **Do not "fix" this with `.nojekyll`**: that turns `/praxen/docs/` into a 404
   and breaks every report users have already generated and shared at 1.0/1.1/1.2,
-  which we cannot reach. Include only if the 85-file diff is acceptable in a
-  patch; otherwise 1.3.
+  which we cannot reach. Keep Jekyll serving `/docs/` as a fallback.
 - **#216 — `SKILL.md` §9.2's worked example describes FinBot verbatim**, including
-  a real finding on a roster/demo target. The fix is prose-only, but it is prose
-  the scanning model reads while authoring `agent_structure_summary`, so it is
-  the one item here with a non-zero (small) chance of nudging output style.
-  If included, pair it with a single spot-check scan before merge.
-- **#151 — Google Antigravity (`agy`) harness**: packaging and docs only, engine
-  unchanged; an external contact is waiting and the 1.3 plan already notes there
-  is no engineering reason to hold it. Additive, but it does open a new support
-  surface — a scope call, not a technical risk.
+  a real finding on a roster/demo target. Prose-only, but it is prose *the
+  scanning model reads* while authoring `agent_structure_summary` — the one item
+  in this release with a non-zero (small) chance of nudging output style.
+  **Gate it with a spot-check scan** of one baseline target before merge; if the
+  result lands outside band, drop the item rather than debug it in a patch.
 - **#106 — clarify Out-of-Scope remit coverage** as boundary-rule checks.
   Authoring-side guidance; no scan-behavior change against committed remits.
+- **#27 — finding default-state (collapsed/expanded) + expand/collapse-all.**
+  A report-UX change, so ordinarily 1.3 — but it lands in `render.py` /
+  `report_template.html` and therefore regenerates exactly the same 85 renders
+  #227 already forces. **If #227 is in, doing #27 in the same pass is nearly
+  free**; doing them in separate releases means paying the regeneration twice.
+  Score-inert either way. Include only if the UX decision (which state is
+  default) is settled — otherwise it is a design question wearing a cleanup's
+  clothes.
+- **#6 — `render.py` / template polish** (finding-card confidence, Medium/Low
+  badge, TXT High findings). The issue itself flags that it re-renders the
+  byte-frozen baselines — which is precisely why it belongs *with* #227/#27
+  rather than after them. Same argument: **the regeneration is a fixed cost, so
+  pay it once.** Score-inert; presentation only.
+- **#135 — docs simplicity pass (Tier 3).** Prose only, no generated-output or
+  scan surface. Scope it to a bounded pass rather than an open-ended rewrite.
+- **#4 — `SKILL.md` authoring aids & clarity leftovers.** Small prose items from
+  an old field review, explicitly "not bugs". Same risk class as #216 — prose the
+  model reads — so **fold it under #216's spot-check gate** and let one scan
+  cover both rather than running two.
+- **#65 items 6–7 — remit-authoring guidance**: the code-first warning block and
+  the mechanism-vs-property note in the remit template. Author-side only; the
+  committed remits 1.2.1 scores against are unchanged, so this is inert for the
+  frozen set.
+
+  ⚠️ **#65 item 8 is NOT in scope, contra the 1.3 plan's note.** That item puts
+  absence-of-evidence confidence calibration into `KB_RAISE_SCANNING.md` — which
+  `SKILL.md:202` loads as the *primary scoring calibration* at Step 3 and uses at
+  Step 8 to score. `RELEASE_1.3_PLAN.md` groups items 6–8 as "safe outside the
+  freeze"; that holds for 6–7 and over-reaches for 8. Editing a scanner-read KB
+  can move scores and belongs with the 1.3 re-freeze.
 
 ## Explicitly NOT in 1.2.1
 
 Each of these moves a number, changes the schema contract, or is a feature —
 all belong to 1.3 (`RELEASE_1.3_PLAN.md`):
+
+Swept the full open-issue list (34 as of 2026-08-03); everything not in scope
+above is here with its reason.
 
 | Item | Why not |
 |---|---|
@@ -132,15 +162,18 @@ all belong to 1.3 (`RELEASE_1.3_PLAN.md`):
 | #198 / #200 / #201 remit work | Remit changes move scores; needs a re-freeze |
 | #195 band anchors · #196 decomposition rule | Scoring/variance surface |
 | #173 / #174 tagging calibration | Changes frozen tags |
-| #41 · #104 detection additions | New findings |
+| #41 detection pattern · #65 items 4–5 (IaC discovery) | New discovery surfaces = new findings |
+| #104 entropy secret detection | Changes what reports redact — alters output content, and it is a detection change |
+| #65 item 8 (KB confidence calibration) | `KB_RAISE_SCANNING.md` is scanner-read primary calibration — **can move scores** (see C) |
 | #70 roster gap | New target = re-baseline |
-| #176 suite_health full 0–5 scale | Explicitly gated on the next re-baseline |
-| #113 `<code>` wrapping in prose fields | **Model-output change** — moves every committed render and is a prose-behavior change |
-| #27 finding collapse/expand | Report UX feature, not a patch fix |
-| #197 Thinking Modes | User-facing feature |
+| #113 `<code>` wrapping in prose fields | **Model-output change** — prose behavior, not presentation |
+| #197 Thinking Modes | User-facing feature, not a cleanup |
 | #117 / #118 operator override + revision records | Schema-contract change |
 | #217 manifest-authoring fragility | Architectural; needs design |
-| #90 design system · #135 docs simplicity pass | Larger efforts |
+| #25 SKILL.md rendering/MVC split | Restructures the file the model reads — too structural for a patch, even as a pure refactor |
+| #176 suite_health full 0–5 scale | Gated on the next re-baseline by its own title. *Worth re-examining* — it looks like presentation over frozen data, so the gate may be conservative; decide deliberately rather than by inheritance |
+| #151 Antigravity harness | **Held (Steve, 2026-08-03)** — additive packaging, but it opens a new supported harness. New surface, not a cleanup |
+| #90 org design system · #2 standing config | Larger efforts; #2 explicitly deferred long-standing |
 
 ## Success criteria
 
@@ -153,9 +186,23 @@ all belong to 1.3 (`RELEASE_1.3_PLAN.md`):
 
 ## Sequencing
 
-A and B are independent and can land in one PR each. Decide C before starting:
-if #227 is in, land it **last and alone**, so the 85-file regeneration is
-reviewable on its own rather than mixed with prose edits.
+Four PRs, in this order:
+
+1. **A (docs)** and **B (CI + bump script)** — independent, one PR each. Land the
+   bump script first and use it to cut this release's own version bump.
+2. **The SKILL prose pair — #216 + #4 — together**, gated by a single spot-check
+   scan of one baseline target. One scan covers both; if it lands outside band,
+   drop the pair rather than debugging prose in a patch.
+3. **The render regeneration — #227 + #27 + #6 — last, and alone.** All three
+   touch `render.py` / `report_template.html` and force the same 85-file
+   regeneration, so they cost one regeneration together and three separately.
+   Landing them alone keeps that large diff reviewable instead of buried under
+   prose edits.
+
+**Verify the regeneration rather than trusting it:** for #227 every changed file's
+diff must be *only* the URL substitution. #27 and #6 legitimately change more, so
+review those diffs on their merits — and confirm no findings JSON moved, which is
+the actual invariant.
 
 Version bump is `1.2.0 → 1.2.1` across the five surfaces listed in **B**.
 `build.sh`'s four-way guard enforces agreement on all but the README badge (it

--- a/plans/RELEASE_1.2_PLAN.md
+++ b/plans/RELEASE_1.2_PLAN.md
@@ -5,7 +5,20 @@
 
 # Praxen 1.2 — Harness Reliability & Scoring Stability
 
-> ## ▶ STATUS: CLOSED — shipped to `dev` 2026-07-30 (main promotion pending, planned 2026-08-04)
+> ## ▶ STATUS: SHIPPED — `v1.2.0` released 2026-08-03
+>
+> **Released a day ahead of the planned 2026-08-04 window**, once the branch was
+> verified clean. Promotion `784203d` (merge commit, `dev` fast-forwarded); a
+> docs-correction promotion followed (`ea8f00b`); tag **`v1.2.0`** cut from `main`
+> with `praxen-1.2.0.zip` (8.19 MB) published; announcement live at
+> [the community blog](https://open-agent-ai-security.github.io/blog/praxen-1-2-release/).
+>
+> **Post-release verification (2026-08-03).** A clean install from the public
+> marketplace scanned **three randomly chosen baseline targets**: uagents **1.70**
+> and autogen-code-executor **1.55** hit their frozen medians exactly, helperbot
+> **0.45** landed at its band edge (median 0.60, band 0.15). `schema_version` 3.0
+> and `praxen_version` 1.2.0 confirmed from the JSON; 2026 OWASP naming
+> throughout; spot-checked findings grounded in real code. No red flags.
 >
 > **The release pivoted from its original frame.** This plan was written as
 > "harness reliability + scoring stability on Opus 4.8." What shipped is **OWASP
@@ -46,6 +59,39 @@
 >   CURRENT-baseline fix**; **news page** reframed + 1.2 release announcement;
 >   **Gemini review gate retired** (#120 closed).
 >
+> **Delivered after this plan was closed (2026-07-31 → 08-03), not in the staged
+> plan below** — all docs/packaging/CI; no findings JSON touched, no score moved:
+> - **Community-marketplace cutover** (#211, #212) — install moves to the canonical
+>   catalog [`open-agent-ai-security/plugins`](https://github.com/open-agent-ai-security/plugins)
+>   for **both Claude Code and OpenAI Codex** (Codex path smoke-verified on CLI
+>   0.146.0). The in-repo `.claude-plugin/marketplace.json` becomes a **legacy
+>   mirror** so existing installs keep updating, with CI drift guarding it
+>   (`marketplace-sync.yml` → `check_marketplace_mirror.py`; fails closed, and
+>   pins the canonical praxen source). Sister repo **socxen** hard-cut to the same
+>   catalog (0.6.5 → 0.6.6) and aligned to praxen's branch model.
+> - **Renderer fix (#215)** — the TXT summary silently deleted route placeholders
+>   (`POST /api/vendors/<id>/invoices` → `/api/vendors//invoices`). Present in
+>   1.1.0 too; the committed golden had the corruption baked in, so no test could
+>   have caught it. **Found by an end-to-end acceptance run** from a marketplace
+>   install, not by the suite.
+> - **DCO privacy-alias fix (#221)** — GitHub rewrites a fork contributor's author
+>   email to `@users.noreply.github.com` on squash-merge, so the sign-off email no
+>   longer matched and the promotion PR failed its own DCO gate on Christopher
+>   Deck's #194 contribution. Would recur for any contributor with email privacy
+>   enabled. Landed on `main` directly — `pull_request_target` runs the workflow
+>   from the **base** branch, so a dev-only fix could not have unblocked it.
+> - **Dependabot retargeted to `dev`** (#218) — it defaulted to the default branch
+>   (`main`, the release channel), which breaks the *main is an ancestor of dev*
+>   invariant.
+> - **Post-release doc corrections** — `STABILITY.md` and
+>   `docs/interpreting-reports.md` still published `schema_version` **2.0** after
+>   3.0 shipped (a downstream consumer following the contract would pin the wrong
+>   major); `SECURITY.md` still declared Praxen pre-`1.0`; `docs/owasp.md` linked a
+>   404'd OWASP Agentic Top 10 URL. All live.
+> - **News-page community-commentary card** for the *When a Security Scan Earns Its
+>   Keep* post; **blog announcement published** with real install commands for both
+>   platforms and links to the project home page.
+>
 > **Deferred → 1.3** (see `RELEASE_1.3_PLAN.md`): **#48 scoring rework** (the PUSH);
 > **#198 remit-generator authoring quality** (the durable fix for the over-reach
 > class) and the **remit-cleanup + re-baseline** on the targets it still affects
@@ -62,6 +108,17 @@
 >   full 0–5 scale in 1.3).
 > - **Open, carried to 1.3:** everything under *Deferred → 1.3* above (#173/#174 are
 >   the remaining tagging-calibration pair).
+>
+> **Filed during the promotion and post-release reviews (2026-07-31 → 08-03)** —
+> none blocked the release; triaged into `RELEASE_1.2.1_PLAN.md` (docs/CI, no
+> score movement) or 1.3: **#216** (SKILL §9.2 example describes FinBot verbatim),
+> **#217** (manifest authoring is the pipeline's fragile step), **#222** (DCO bot
+> exemption should use a login allowlist), **#224** (SKILL Step 9.9
+> `--validate-manifest` example is unrunnable), **#225** / **#226** (docs-review
+> findings), **#227** (report tag chips point at the unstyled Jekyll `/docs/`
+> render — *do not* fix with `.nojekyll`, which would 404 reports already in
+> users' hands). **#209** items 2–3 remain open (dependabot auto-merge gating,
+> SHA-pinned actions); item 1 shipped.
 >
 > The staged plan below is retained as the historical record.
 

--- a/plans/RELEASE_1.3_PLAN.md
+++ b/plans/RELEASE_1.3_PLAN.md
@@ -11,6 +11,11 @@
 > remit-generator / over-reach class below). **Reference model is now Opus 5** —
 > 1.3 grades vs **`v1.2-opus5`**, not `v1.2-claude48`. Branches from `dev` after
 > the 1.2 → main promotion.
+>
+> **`v1.2.0` shipped 2026-08-03.** A score-inert patch, **`RELEASE_1.2.1_PLAN.md`**,
+> is drafted ahead of this release for the docs/CI tail from the promotion reviews
+> — anything that moves a number stayed here. If 1.2.1 ships first, 1.3 branches
+> from `dev` after it.
 
 ## Objective
 


### PR DESCRIPTION
Two things: bring `RELEASE_1.2_PLAN.md` in line with what actually shipped, and draft a score-inert `RELEASE_1.2.1_PLAN.md`.

## 1.2 close-out

The status block still read *"shipped to `dev` 2026-07-30 (main promotion pending)"* and predated a week of late work. Now:

- **STATUS → SHIPPED**, `v1.2.0` released **2026-08-03** — promotion `784203d`, docs-correction promotion `ea8f00b`, tag + 8.19 MB zip, announcement live
- **Post-release verification recorded**: three randomly chosen baseline targets scanned from a clean marketplace install — uagents 1.70 and autogen 1.55 hit their frozen medians *exactly*, helperbot 0.45 at its band edge
- **New section for work delivered after close-out**: the community-marketplace cutover (both platforms) + legacy mirror + CI drift gate, socxen's hard cut, the TXT route-placeholder renderer fix (#215 — present in 1.1.0 too, and invisible to the suite because the committed golden had the corruption baked in), the DCO privacy-alias fix (#221), dependabot retargeting (#218), and the post-release doc corrections
- **Issue reconciliation extended** with everything filed during the promotion and post-release reviews, each routed to 1.2.1 or 1.3

## 1.2.1 draft

The entry criterion is stated up front and every item is tested against it: **no findings JSON, no re-scan, no re-freeze, no schema change** — so 1.2.1 ships against the existing `v1.2-opus5` baseline.

- **A · Docs** — the #225/#226 tail: `tests/README.md` contradicting itself on schema 2.0 vs 3.0 and pointing release review at the archival baseline, `v1.0.0+` confirm lines with no 1.1→1.2 upgrade guidance, scan-diff shipped-but-undocumented, and #224's unrunnable `--validate-manifest` example
- **B · CI hygiene** — #222 (DCO bot allowlist), #209 items 2–3 (dependabot auto-merge gating, SHA-pinned actions)
- **C · Needs a call, not assumed in** — **#227** (score-inert but regenerates **85 committed renders**; the `.nojekyll` trap is spelled out so nobody takes the easy-looking fix), **#216** (prose the scanning model reads → small output-style risk, so pair it with a spot-check scan), **#151** Antigravity, **#106**

A table records **what is excluded and why** — #48, the remit work, detection adds, #113, #176 and the rest — so the boundary is auditable rather than remembered.

Also notes in the plan that *merging the promotion is what ships now*, since the catalog pins `main`.

## Verification
`./build.sh` green · suite **245 / 0** · **zero** files touched under `tests/baselines/`, `examples/`, or `skills/` — plan documents only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)