### PR TITLE
plans(1.2.1): take #193, folded into the SHA-pinning work

### DIFF
--- a/plans/RELEASE_1.2.1_PLAN.md
+++ b/plans/RELEASE_1.2.1_PLAN.md
@@ -68,6 +68,26 @@ large, and it is optional for this release.
   branch has no required checks. Gate it.
 - **#209 item 3 — SHA-pin GitHub Actions** rather than floating major tags.
   Dependabot (now correctly targeting `dev`) keeps them current.
+- **#193 — `actions/setup-python` 6 → 7 — fold into the SHA-pinning above, do
+  not merge it standalone.** Parked through the 1.2.0 launch on purpose; the
+  launch is done, so it can proceed. Two reasons to merge it *as part of* item 3
+  rather than on its own:
+  1. **It is incomplete.** #193 touches `ci.yml` and `release.yml` only —
+     `marketplace-sync.yml` was added *after* dependabot opened it, so merging as-is
+     leaves setup-python at v7 in three places and **v6 in one**. Pin all four
+     together (`ci.yml` ×2, `release.yml`, `marketplace-sync.yml`).
+  2. **Pinning supersedes bumping.** SHA-pinning means choosing the SHA of the
+     version you want; doing the bump first and the pin second edits the same
+     four files twice.
+
+  ⚠️ **Known risk, now acceptable:** `release.yml` is tag-triggered, so no PR run
+  ever exercises it — **1.2.1's own tag push will be the first execution of
+  setup-python v7 in the release workflow.** That is precisely why this was held
+  out of 1.2.0: a failure there would have broken the flagship release build. On
+  a patch it is a recoverable place to find out. Watch the release run rather than
+  assuming it, and note that re-running a failed run replays the *old* workflow
+  definition — a fix needs a new tag, and this project does not re-point published
+  tags.
 - **`scripts/bump_version.py`** *(new — Steve, 2026-08-03)*. Praxen keeps the
   version in **five** places and edits every one of them by hand:
 


### PR DESCRIPTION
Answers *should #193 go in 1.2.1?* — **yes**, but not as a standalone merge.

It is CI-only and score-inert, and the reason it was parked (its `release.yml` change is first executed by a **tag push**, which would have been the 1.2.0 launch build) no longer applies now that 1.2.0 has shipped.

## Why fold it into #209 item 3 rather than merge it

1. **#193 is incomplete.** It touches `ci.yml` and `release.yml` only — `marketplace-sync.yml` was added *after* dependabot opened it. Merging as-is leaves `setup-python` at **v7 in three places and v6 in one**.
2. **Pinning supersedes bumping.** SHA-pinning (#209 item 3, already in scope) means choosing the SHA of the version you want; bump-then-pin edits the same four files twice.

## Residual risk, recorded not dropped

`release.yml` is tag-triggered, so no PR run exercises it — **1.2.1's own tag push will be the first real execution of setup-python v7 there.** That is exactly why it was held out of 1.2.0; on a patch it is a recoverable place to find out. The note also flags that **re-running a failed run replays the old workflow definition** (the lesson from #219's DCO re-run), so recovery needs a new tag — and this project does not re-point published tags.

Plans only; `build.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)