### PR TITLE
mirror: drop socxen from the legacy mirror (#235) — fast-tracked ahead of socxen#66

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/open-agent-ai-security"
   },
   "metadata": {
-    "description": "Open Agent AI Security's Claude Code plugin marketplace — legacy mirror. The canonical index is https://github.com/open-agent-ai-security/plugins; this in-repo copy serves existing installs added from open-agent-ai-security/praxen and is kept in sync by CI.",
+    "description": "Open Agent AI Security's Claude Code plugin marketplace — legacy mirror carrying praxen only. The canonical index is https://github.com/open-agent-ai-security/plugins; this in-repo copy serves existing installs added from open-agent-ai-security/praxen and is kept in sync by CI. Other community plugins install from the canonical index.",
     "version": "1.2.0"
   },
   "plugins": [
@@ -20,25 +20,6 @@
         "ai-agent-security",
         "raise-framework",
         "owasp"
-      ],
-      "category": "security"
-    },
-    {
-      "name": "socxen",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/open-agent-ai-security/socxen.git",
-        "ref": "main"
-      },
-      "description": "socxen — agentic SOC analyst. Triages Exabeam New-Scale alerts and cases end to end via the Exabeam MCP: gathers evidence, correlates activity, reaches a threat/false-positive verdict, and acts — containment recommended for human approval, and dismiss/close gated by Claude Code permission rules.",
-      "license": "Apache-2.0",
-      "keywords": [
-        "soc",
-        "soc-analyst",
-        "alert-triage",
-        "exabeam",
-        "ai-agent-security",
-        "mcp"
       ],
       "category": "security"
     }

--- a/build.sh
+++ b/build.sh
@@ -32,9 +32,9 @@ if [[ "$VERSION" != "$PLUGIN_VERSION" ]]; then
   echo "error: version mismatch — PRAXEN_SPEC.md says $VERSION, plugin.json says $PLUGIN_VERSION" >&2
   exit 1
 fi
-# Look the praxen entry up BY NAME: the mirror lists other plugins too (which
-# deliberately carry no version, mirroring the canonical index), so a positional
-# read would crash on a reordering rather than checking what it means to check.
+# Look the praxen entry up BY NAME, never positionally: the mirror is
+# praxen-only today (#235), but a by-name read stays correct if entries are
+# ever added or reordered, rather than silently checking the wrong one.
 MARKET_VERSION="$(python3 -c "import json, sys
 m = json.load(open('.claude-plugin/marketplace.json'))
 e = next((p for p in m['plugins'] if p.get('name') == 'praxen'), None)

--- a/scripts/release/check_marketplace_mirror.py
+++ b/scripts/release/check_marketplace_mirror.py
@@ -6,13 +6,18 @@
 The canonical Claude Code marketplace for the org lives in
 https://github.com/open-agent-ai-security/plugins; this repo keeps an in-repo
 mirror so installs added from the legacy path (open-agent-ai-security/praxen)
-keep updating. The two files may differ in exactly three places:
+keep updating. The two files may differ in exactly four places:
 
   - the praxen entry's ``source`` ("./" here vs a pinned git URL there);
   - the praxen entry's ``version`` (required here by build.sh's version guard;
     absent there, where each plugin repo's plugin.json is the version
     authority);
-  - ``metadata`` prose (the mirror says it is a mirror).
+  - ``metadata`` prose (the mirror says it is a mirror);
+  - the mirror may OMIT canonical entries other than praxen (#235): the mirror
+    exists for legacy-praxen continuity only, and carrying sibling plugins
+    would acquire new users onto a deprecated channel — and couple this repo
+    to every sibling's layout changes. The praxen entry is REQUIRED here, and
+    an entry the mirror carries that the canonical index lacks is still drift.
 
 Everything else fails closed: entries are compared by FULL equality after
 excluding only those exemptions, and the top level likewise (full equality
@@ -135,9 +140,17 @@ def main() -> int:
                 f"{c_praxen_src!r} != {EXPECTED_CANONICAL_PRAXEN_SOURCE!r}"
             )
 
-    if set(c_by_name) != set(m_by_name):
+    # Set comparison is asymmetric by design (#235): the mirror serves legacy
+    # praxen installs only, so it may omit sibling plugins the canonical index
+    # carries — but it must always carry praxen, and it must never carry an
+    # entry the canonical index lacks (a mirror-only plugin would be a
+    # distribution channel nothing validates).
+    if "praxen" not in m_by_name:
+        drift.append("mirror has no praxen entry — the one plugin it exists to serve")
+    mirror_only = sorted(set(m_by_name) - set(c_by_name))
+    if mirror_only:
         drift.append(
-            f"plugin sets differ: canonical {sorted(c_by_name)} vs mirror {sorted(m_by_name)}"
+            f"mirror carries entries absent from the canonical index: {mirror_only}"
         )
 
     for name in sorted(set(c_by_name) & set(m_by_name)):

--- a/scripts/release/check_marketplace_mirror.py
+++ b/scripts/release/check_marketplace_mirror.py
@@ -139,6 +139,15 @@ def main() -> int:
                 f"canonical praxen source deviates from the expected pin: "
                 f"{c_praxen_src!r} != {EXPECTED_CANONICAL_PRAXEN_SOURCE!r}"
             )
+    # The MIRROR praxen source is likewise exempt from the entry comparison
+    # (normalized() pops it), so pin it too: it must be exactly "./" — this
+    # repo serving its own plugin. (#236 review finding; previously only
+    # test_plugin_manifests.py caught a tampered mirror source.)
+    if "praxen" in m_by_name and m_by_name["praxen"].get("source") != "./":
+        drift.append(
+            f"mirror praxen source must be './' (this repo), "
+            f"got {m_by_name['praxen'].get('source')!r}"
+        )
 
     # Set comparison is asymmetric by design (#235): the mirror serves legacy
     # praxen installs only, so it may omit sibling plugins the canonical index


### PR DESCRIPTION
Fast-tracked to **main** on Steve's call (2026-08-05: separate path, "timing is more urgent" — socxen#66 targets this week and its canonical-index flip would otherwise red praxen's weekly drift cron). Deliberately NOT part of 1.2.1: no version bump, CI/packaging metadata only.

- **Mirror** (`.claude-plugin/marketplace.json`): socxen entry removed; metadata says "carrying praxen only" and points siblings at the canonical index. Rationale per #235 — zero socxen installs on the legacy channel, so the entry's only effect was acquiring users onto a deprecated path, plus permanent coupling to socxen's layout.
- **Drift check** (`scripts/release/check_marketplace_mirror.py`): the omission is now the fourth documented mirror↔canonical difference, asymmetric and fail-closed — mirror may omit non-praxen canonical entries; **praxen is required in the mirror**; mirror-only entries are still drift.

Verified: live check green against the current canonical (which still lists socxen — omission working as intended); negative tests confirm both fail-closed paths still trip (mirror-only entry, deviated canonical praxen source). `test_plugin_manifests.py` 17/17 (the dropped check was the socxen-entry check), `./build.sh` green.

**After merge:** dev needs a merge-back (`main` → `dev` merge commit) to keep the ancestry invariant; I'll do that on request. The plugins-repo side of socxen#66 (validator must learn `git-subdir` before the index flips) is separate and still open.

Closes #235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)