### PR TITLE
Promote dev → main: project-level pill + MEA news coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 # Praxen
 **agent behavior verifier**
 
+[![Project level: Flagship](https://img.shields.io/badge/project_level-flagship-8366f5)](https://open-agent-ai-security.github.io/project-levels/)
 [![CI](https://github.com/open-agent-ai-security/praxen/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agent-ai-security/praxen/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/badge/release-v1.2.0-blue)](https://github.com/open-agent-ai-security/praxen/releases)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](LICENSE)

--- a/news.html
+++ b/news.html
@@ -211,7 +211,7 @@
         </p>
         <div class="topline">
           <div class="stat"><strong>35+</strong><span>press placements</span></div>
-          <div class="stat"><strong>16</strong><span>editorial features</span></div>
+          <div class="stat"><strong>17</strong><span>editorial features</span></div>
           <div class="stat"><strong>10+</strong><span>community voices</span></div>
         </div>
       </div>
@@ -239,6 +239,11 @@
       <div class="wrap">
         <h2>Editorial coverage</h2>
         <div class="cov-grid">
+          <a class="cov-card" href="https://enterpriseitworldmea.com/the-new-insider-threat-why-ai-agents-need-governance-before-they-need-access/" target="_blank" rel="noopener">
+            <div class="cov-outlet">Enterprise IT World MEA</div>
+            <p class="cov-title">The New Insider Threat: Why AI Agents Need Governance Before They Need Access — Exabeam's Mazen Dohaji on verifying agent behavior with Praxen before granting enterprise access</p>
+            <span class="cov-read">Read →</span>
+          </a>
           <a class="cov-card" href="https://siliconangle.com/2026/06/23/exabeam-launches-praxen-open-source-tool-verify-ai-agent-behavior/" target="_blank" rel="noopener">
             <div class="cov-outlet">SiliconANGLE</div>
             <p class="cov-title">Exabeam launches Praxen, an open-source tool to verify AI agent behavior</p>

--- a/plans/RELEASE_1.2.1_PLAN.md
+++ b/plans/RELEASE_1.2.1_PLAN.md
@@ -68,6 +68,26 @@ large, and it is optional for this release.
   branch has no required checks. Gate it.
 - **#209 item 3 — SHA-pin GitHub Actions** rather than floating major tags.
   Dependabot (now correctly targeting `dev`) keeps them current.
+- **#193 — `actions/setup-python` 6 → 7 — fold into the SHA-pinning above, do
+  not merge it standalone.** Parked through the 1.2.0 launch on purpose; the
+  launch is done, so it can proceed. Two reasons to merge it *as part of* item 3
+  rather than on its own:
+  1. **It is incomplete.** #193 touches `ci.yml` and `release.yml` only —
+     `marketplace-sync.yml` was added *after* dependabot opened it, so merging as-is
+     leaves setup-python at v7 in three places and **v6 in one**. Pin all four
+     together (`ci.yml` ×2, `release.yml`, `marketplace-sync.yml`).
+  2. **Pinning supersedes bumping.** SHA-pinning means choosing the SHA of the
+     version you want; doing the bump first and the pin second edits the same
+     four files twice.
+
+  ⚠️ **Known risk, now acceptable:** `release.yml` is tag-triggered, so no PR run
+  ever exercises it — **1.2.1's own tag push will be the first execution of
+  setup-python v7 in the release workflow.** That is precisely why this was held
+  out of 1.2.0: a failure there would have broken the flagship release build. On
+  a patch it is a recoverable place to find out. Watch the release run rather than
+  assuming it, and note that re-running a failed run replays the *old* workflow
+  definition — a fix needs a new tag, and this project does not re-point published
+  tags.
 - **`scripts/bump_version.py`** *(new — Steve, 2026-08-03)*. Praxen keeps the
   version in **five** places and edits every one of them by hand:
 


### PR DESCRIPTION
Docs-only promotion:

- #238 — Flagship project-level pill in the README, linking to the community's [project levels page](https://open-agent-ai-security.github.io/project-levels/)
- #239 — Enterprise IT World MEA article added to news.html Editorial coverage (stat 16 → 17)
- 1.2.1 plan doc update that was already queued on dev (#232)

No product code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)