### PR TITLE
Promote post-1.2.1 plans sync to main

### DIFF
--- a/plans/DESIGN_THINKING_MODES.md
+++ b/plans/DESIGN_THINKING_MODES.md
@@ -5,10 +5,10 @@
 
 # Design — Praxen Thinking Modes (#197)
 
-> **STATUS: DESIGN — approved for design 2026-08-10** (Steve: "Think hard about
-> it then generate a design"). Implementation unscheduled; candidate satellite
-> release, freeze-independent (see §8). Kept separate from `RELEASE_1.3_PLAN.md`
-> by request.
+> **STATUS: DESIGN — approved 2026-08-10; ships as release 1.3** (the accuracy
+> release — see `RELEASE_1.3_PLAN.md`), deliberately **ahead of** the
+> detection/re-baseline release, which renumbered to 1.4. Ordering rationale in
+> the 1.3 plan. Freeze-independent by construction (see §8).
 
 ## 1. Purpose
 
@@ -153,11 +153,17 @@ rules. One canonical findings JSON, one report — plus:
 
 - **Claude Code:** subagents give real context isolation for the auditor /
   the three scan runs / the adjudicator. Full automation.
-- **Codex (today):** no equivalent subagent isolation — fallback is
-  sequential phases where phase 1 writes the audit brief + inputs to disk and
-  the operator starts a **fresh session** for the audit phase. Semi-automated,
-  honestly documented as such. Parity tracked; the design assumes nothing
-  Claude-specific in the artifacts themselves.
+- **Codex:** reports the same capability — sub-agents spawned with
+  `fork_turns="none"` get a genuinely fresh context (no parent conversation
+  history), async, same workspace. Full automation on both primary harnesses;
+  **verify empirically at implementation time** (a quick isolation probe: the
+  child must not know a fact only the parent context holds) before relying on
+  it. Shared-workspace caveat: phases write to disk sequentially, so no
+  simultaneous-edit coordination is needed.
+- **Any other harness:** fallback is sequential phases where phase 1 writes
+  the audit brief + inputs to disk and the operator starts a **fresh session**
+  for the audit phase. Semi-automated, honestly documented as such. The
+  artifacts themselves assume nothing harness-specific.
 - Docs state plainly: isolation quality is what makes the audit worth
   anything; a harness that can't isolate gets the manual-fresh-session recipe,
   not a fake same-context "audit."

--- a/plans/DESIGN_THINKING_MODES.md
+++ b/plans/DESIGN_THINKING_MODES.md
@@ -1,0 +1,213 @@
+<!--
+  Copyright 2026 Exabeam, Inc.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Design — Praxen Thinking Modes (#197)
+
+> **STATUS: DESIGN — approved for design 2026-08-10** (Steve: "Think hard about
+> it then generate a design"). Implementation unscheduled; candidate satellite
+> release, freeze-independent (see §8). Kept separate from `RELEASE_1.3_PLAN.md`
+> by request.
+
+## 1. Purpose
+
+Operationalize our proven manual best practices for the "fuzzy" parts of a
+scan, as opt-in accuracy tiers — the way LLMs expose effort levels. Two facts
+motivate this:
+
+- The 1.2 post-freeze **FP scrub** (one independent, context-unaware reviewer
+  per target) worked: zero detector false positives confirmed, and a recurring
+  remit over-reach class surfaced that nothing else had caught.
+- The **median-of-3** baseline discipline works, but as used today it only
+  *measures* variance; the discovery half (what runs find that other runs
+  miss) is thrown away.
+
+Thinking modes automate both. They are **complementary to, not a substitute
+for, single-run accuracy work** (#48, #195, #196, #198 — prompt engineering,
+python translation of judgment-free steps, rubric sharpening). Those shrink
+variance at the source; as long as an LLM is in the loop, residual variance
+remains — the modes damp what remains.
+
+## 2. The modes
+
+| Mode | What runs | Cost (rough) | When |
+|---|---|---|---|
+| **standard** | Today's scan, byte-for-byte unchanged | 1× | Default. Baselines, bands, everyday scans |
+| **high** | Scan → context-unaware findings audit → cleanup + re-render | ~2× | Before a report leaves your hands |
+| **x-high** | 3 independent scans → union → evidence adjudication → one super-run | ~4–5× | Audits, gates, anything where quality outranks time/tokens |
+
+Selected per-invocation in natural language ("run a Praxen analysis in high
+thinking mode"). No config file, no standing state (consistent with #2's
+deferral). Unrecognized/absent mode ⇒ standard.
+
+## 3. First principles
+
+1. **Evidence decides membership; run-count decides nothing.** A finding seen
+   by one run of three that survives refutation against the code **stays**. A
+   finding seen by all three that fails verification **dies**. Vote counting —
+   in either direction — is consensus-by-the-back-door and is banned.
+2. **No score selection, no score blending.** The x-high score is **re-derived
+   from the adjudicated finding set** by the normal SKILL scoring rules — a
+   real single scan's score computed on better-vetted inputs. This keeps the
+   standing rule intact: the product is one scan → one score; we never
+   union/median/average scores as a user-facing deliverable.
+3. **The auditor is genuinely context-unaware.** A fresh agent that receives
+   only: the findings JSON, the remit, and the workspace — with an explicit
+   refutation mandate. A same-session "review your own findings" pass inherits
+   the scan's confirmation bias and is worthless; this is what made the manual
+   scrubs work.
+4. **Every disagreement becomes a diagnostic.** Cross-run flips and audit
+   kills are logged as a variance artifact. "Found once, refuted" = detector
+   wobble (feeds #48/#195/#196). "Found by all three, refuted" = systematic
+   error, likely remit-defect class (feeds #198). The mode both improves the
+   run *and* generates the raw material for fixing the detector — honoring
+   "a flipping finding = fix the detector, not aggregate runs."
+
+## 4. High mode — pipeline
+
+**Phase 1 — standard scan to completion.** Full pipeline through validated
+canonical JSON + rendered report. If later phases fail or are aborted, the
+operator still holds a complete standard result (graceful degradation).
+
+**Phase 2 — findings audit.** Fresh context-unaware agent (subagent where the
+harness supports it; see §7). Inputs: findings JSON, remit, workspace path,
+and a written audit brief. Mandate: for **each** finding, re-read every cited
+artifact and attempt refutation. Verdict per finding — three-way, because the
+1.2 scrub proved the binary version discards the most valuable signal:
+
+- **CONFIRMED** — evidence holds as cited.
+- **UNSUPPORTED** — the cited evidence does not support the claim (wrong
+  reading, stale line, over-claim beyond what the code shows).
+- **REMIT-DEFECT** — the evidence holds and the finding honestly violates the
+  rule *as written*, but the rule itself is fabricated, over-reaching, or
+  contradicts documented behavior (the #198/#200/#201 class).
+
+Guardrails against an over-zealous auditor: a verdict of UNSUPPORTED requires
+citing what the auditor actually read that contradicts the claim — "could not
+verify quickly" is CONFIRMED-by-default territory, not a kill; severity
+re-grading is out of scope (that's #48's axis); the auditor never proposes new
+findings (discovery is x-high's job, via more runs — not the auditor's).
+
+**Phase 3 — cleanup + re-render.** UNSUPPORTED findings are removed from the
+findings JSON (original IDs are never reused; gaps are provenance).
+REMIT-DEFECT findings are removed from the findings register and recorded as
+**remit feedback** in the adjudication artifact — the remit owner's fix list,
+not the agent's risk list. RAISE category scores are re-derived **only** where
+a removed finding was load-bearing in that category's rationale. Pipeline
+re-runs (manifest → findings → render) to produce the final report.
+
+## 5. X-high mode — pipeline
+
+**Phase 1 — three independent standard scans.** Fresh context each, zero
+shared state, parallel subagents where the harness supports them (the
+regression suite already runs 4–8 concurrent), sequential otherwise. Three
+canonical findings JSONs.
+
+**Phase 2 — union + matching.** Findings matched across runs by **rule text +
+evidence overlap + claim semantics — never R-IDs** (rule IDs are run-local
+enumerations). `tests/scan_diff.py` is the assist tool, with its known limit
+treated as a rule: the 0.40 join threshold under-matches rewordings, so every
+"unmatched" item is hand-verified by the adjudicator before being treated as
+unique. Output: the deduplicated union, each entry carrying found-in-runs
+provenance.
+
+**Phase 3 — adjudication.** Fresh context-unaware adjudicator applies the
+§4 audit (same three-way verdicts, same guardrails) to **every union member**
+— principle 1 governs: membership is decided by evidence alone. For matched
+duplicates, the canonical record is the instance whose evidence chain verified
+most completely (selection over synthesis — verifiable provenance beats
+blended prose); verified evidence citations from sibling instances may be
+merged into its evidence list.
+
+**Phase 4 — super-run assembly.** The adjudicated set gets fresh sequential
+IDs (per-run IDs recorded in the adjudication artifact). Category scores and
+all report prose are re-derived from the adjudicated set per normal scoring
+rules. One canonical findings JSON, one report — plus:
+
+- **Adjudication record** — per finding: found-in runs, verdict, evidence
+  status, source instance, rationale.
+- **Variance diagnostic** — the flip inventory (found-in-1 verified / refuted,
+  found-in-3 refuted, score spread of the three raw runs vs the final derived
+  score). This is the #48 feedstock and gets attached to any future
+  re-baseline analysis.
+
+## 6. Artifacts, schema, and what stays untouched
+
+- **Canonical findings JSON: schema 3.0, no new fields, v1.** The mode and
+  adjudication live in a separate artifact
+  (`reports/<slug>-adjudication-<timestamp>.md`) plus naturally in the
+  report's existing prose fields. A proper `scan_mode` / revision-provenance
+  schema field is deliberately deferred to ride a re-baseline release together
+  with #118 (operator overrides want the same provenance shape — design once).
+- **`report_template.html` / `render.py`: untouched.** Standard-mode renders
+  must remain byte-identical (the render gate enforces this); nothing in v1
+  requires a template change.
+- **Skill packaging:** mode instructions live in a **separate file**
+  (`skills/behavior-verifier/THINKING_MODES.md`) loaded only when a
+  non-standard mode is requested. SKILL.md gains only a short pointer. That
+  pointer is a skill-prose change and gets the #216 treatment: a blind
+  standard-mode gate scan of a baseline target must land in-band before ship.
+
+## 7. Harness reality
+
+- **Claude Code:** subagents give real context isolation for the auditor /
+  the three scan runs / the adjudicator. Full automation.
+- **Codex (today):** no equivalent subagent isolation — fallback is
+  sequential phases where phase 1 writes the audit brief + inputs to disk and
+  the operator starts a **fresh session** for the audit phase. Semi-automated,
+  honestly documented as such. Parity tracked; the design assumes nothing
+  Claude-specific in the artifacts themselves.
+- Docs state plainly: isolation quality is what makes the audit worth
+  anything; a harness that can't isolate gets the manual-fresh-session recipe,
+  not a fake same-context "audit."
+
+## 8. Baselines, bands, and release packaging
+
+- Frozen baselines and per-target bands are **standard-mode artifacts**.
+  Thinking-mode outputs are never graded against standard bands, and no
+  baseline is ever frozen in a thinking mode. Docs state cross-mode scores are
+  not comparable-by-band (expected direction: equal or cleaner).
+- **Freeze-independent satellite.** Standard path unchanged (modulo the
+  gate-scanned SKILL pointer), no schema change, no template change ⇒ this can
+  ship as a 1.2.x satellite or alongside 1.3 without riding the v1.3-opus5
+  freeze. If implementation slips into 1.3 proper, it still doesn't join the
+  freeze-gated bucket.
+
+## 9. Acceptance
+
+1. **High-mode proof (regression against the human scrubs):** run high mode on
+   the 1.2 FP-scrub targets; the audit must independently surface the same
+   remit over-reach catches the human scrub logged (scrub reports exist as
+   ground truth). Spot-check every UNSUPPORTED verdict by hand on the first
+   runs — audit precision is the make-or-break metric; an auditor that kills
+   true positives is worse than no auditor.
+2. **X-high stability proof:** two full x-high super-runs on a historically
+   wide-band target (autogen or uAgents). Success = super-run finding sets
+   near-identical and score delta well inside the target's historical
+   single-run band. A super-run *pair* that wobbles like single runs means the
+   adjudication isn't doing its job.
+3. **Standard-mode non-regression:** byte-identical renders (existing gate)
+   plus the blind in-band gate scan for the SKILL pointer change.
+4. **Duplicate audit:** the x-high output contains no unmatched duplicates
+   (scan_diff assist + adjudicator hand-check is the mitigation; this test is
+   the proof it worked).
+
+## 10. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Over-zealous auditor kills true positives | Refutation requires cited contradicting evidence; CONFIRMED is the default when evidence holds; hand spot-check on first runs (§9.1) |
+| Matching errors (dupes or false-uniques) in x-high | scan_diff assist + mandatory hand-verification of unmatched items; §9.4 |
+| Adjudicator context pressure on large targets | Artifact-driven pipeline — all inputs on disk; adjudicate in finding-batches, never "hold everything in context" |
+| Manifest fragility ×4 (#217) | Mid-draft `--validate-manifest` is already standard practice; x-high multiplies exposure, not failure modes |
+| Codex isolation weaker | Fresh-session fallback documented as semi-automated; no pretend-isolation |
+| Cost surprise | Mode table (§2) in docs; the skill states the expected multiple when a mode is invoked |
+
+## 11. Issue map
+
+#197 (this design) · consumes/feeds: #48, #195, #196 (variance diagnostics) ·
+#198, #200, #201 (REMIT-DEFECT verdicts are the generator's fix list) · #118
+(schema provenance — deferred, designed together later) · #217 (manifest
+fragility, multiplied not changed) · #2 (no standing config — modes stay
+per-invocation).

--- a/plans/RELEASE_1.2.1_PLAN.md
+++ b/plans/RELEASE_1.2.1_PLAN.md
@@ -5,7 +5,7 @@
 
 # Praxen 1.2.1 — Fast-follow patch (docs, CI, packaging)
 
-> ## ▶ STATUS: ACTIVE — approved 2026-08-05 (Steve: "make a 1.2.1 branch and start the work"); working branch `1.2.1` off `dev`
+> ## ✅ STATUS: SHIPPED — v1.2.1 released 2026-08-10 (tag `v1.2.1`, promotion PR #241, independent checkpoint review passed, post-release install+scan smoke clean, blog live). Approved 2026-08-05 (Steve: "make a 1.2.1 branch and start the work"); working branch `1.2.1` off `dev`
 >
 > Drafted immediately after the `v1.2.0` release from the promotion and
 > post-release reviews. **Everything here is deliberately score-inert**: no

--- a/plans/RELEASE_1.3_PLAN.md
+++ b/plans/RELEASE_1.3_PLAN.md
@@ -56,9 +56,10 @@ during 1.2; deferred on the rest. The durable fix is generation-side — do it
 - **#196** — tighten the Step-8.5 fold-vs-break-out decomposition rule
   (finding-count variance). Same axis as #48 and the decomposition-independence
   generalization below — land them together.
-- **#197** — Thinking Modes: opt-in high-fidelity accuracy tiers (High = post-scan
-  FP review; X-High = 3-scan consensus). User-facing; no baseline impact — may
-  ship as a satellite ahead of the freeze.
+- **#197** — Thinking Modes: opt-in high-fidelity accuracy tiers. **Designed
+  2026-08-10 — see `plans/DESIGN_THINKING_MODES.md`** (evidence-adjudicated,
+  not consensus-counted; scores re-derived, never blended). User-facing; no
+  baseline impact — may ship as a satellite ahead of the freeze.
 
 ## Carried from the 1.2 Stage-1 gate — decomposition-independence generalization
 

--- a/plans/RELEASE_1.3_PLAN.md
+++ b/plans/RELEASE_1.3_PLAN.md
@@ -3,182 +3,92 @@
   SPDX-License-Identifier: Apache-2.0
 -->
 
-# Praxen 1.3 — Detection Coverage, Output Quality & Reach
+# Praxen 1.3 — Thinking Modes (the accuracy release)
 
-> Drafted 2026-07-15 alongside the revised `RELEASE_1.2_PLAN.md`; **re-triaged at
-> the 1.2 close-out (2026-07-30)** now that 1.2 has frozen (shipped to `dev`).
-> Holds everything cut from 1.2, plus what 1.2 pushed (#48) or newly surfaced (the
-> remit-generator / over-reach class below). **Reference model is now Opus 5** —
-> 1.3 grades vs **`v1.2-opus5`**, not `v1.2-claude48`.
+> **STATUS: PLANNED — approved 2026-08-10** (Steve: numbering + ordering
+> confirmed; "Modify the plans accordingly"). Branches from `dev` after the
+> post-1.2.1 plans sync lands on `main`. **Ships before the detection /
+> re-baseline release, which is now 1.4** (`RELEASE_1.4_PLAN.md` — formerly
+> the 1.3 plan; renumbered when this feature was promoted from "1.2.x
+> satellite" to its own minor release).
 >
-> **`v1.2.0` shipped 2026-08-03; `v1.2.1` shipped 2026-08-10** (score-inert, per
-> `RELEASE_1.2.1_PLAN.md` — now STATUS: SHIPPED). 1.2.1 absorbed the docs/CI tail
-> plus several items this plan had parked: **#106, #135, #4, #6 (complete, as a
-> linked confidence bubble), #65 items 6–7** — struck below. Anything that moves
-> a number stayed here. **1.3 branches from `dev` after the 1.2.1 promotion
-> (`c004640`).** Re-triaged at the 1.2.1 close-out, 2026-08-10.
+> The design is the contract: **`plans/DESIGN_THINKING_MODES.md`** (#197).
+> This plan only adds release packaging around it.
 
 ## Objective
 
-With scans reliable and scores stable (1.2), widen what Praxen *finds* and
-polish what it *emits*. Detection additions move numbers → 1.3 re-freezes
-**`v1.3-opus5`**, graded vs **`v1.2-opus5`**. That freeze is why the detection
-items travel together here rather than dribbling in: one release, one freeze.
+Ship opt-in accuracy tiers — **standard / high / x-high** — that
+operationalize the proven manual practices for the fuzzy parts of a scan (the
+1.2 FP scrub, the multi-run discipline), per the design's first principles:
+evidence decides membership, run-count decides nothing; scores are re-derived
+from the adjudicated finding set, never selected or blended; the auditor is
+context-unaware; every disagreement becomes a variance diagnostic.
 
-## Arrived from 1.2 — #48 (Stage-2.5 PUSH — confirmed 2026-07-30)
+**Score-inert by construction.** Standard path stays byte-identical; no
+schema change; no template change; no re-freeze. `v1.2-opus5` remains the
+current baseline set, and 1.3 output is never graded against standard-mode
+bands.
 
-1.2's Stage-2.5 decision was **PUSH**: the scoring rework was reverted to
-shipped-state (Steve, 2026-07-28 — the headline pivoted to OWASP 2026), so **#48
-lands here**, sequenced **before** bucket A's detection additions so its
-before/after grading window isn't contaminated by new findings. It rides this
-release's re-freeze at no extra freeze cost. The clean "before" is the frozen
-**`v1.2-opus5`** baseline (single-scan reproducibility is the target, on the
-Opus-5 stack); the earlier `tests/runs/v1.2-stage2.5/` characterization was on
-Opus 4.8 and is now historical only.
+## Why before 1.4 (the ordering decision, 2026-08-10)
 
-## New from the 1.2 baseline experience — remit-generator quality & over-reach cleanup
+1.4 is the scan-heaviest, judgment-heaviest release planned — #48 before/after
+grading, #200/#201 remit re-scrubs, detection proof cases, a full 12-target
+re-freeze. Building the modes first means: high mode runs the re-scrubs the
+humans ran in 1.2; x-high's variance diagnostics are the #48/#195/#196
+feedstock, generated as a byproduct; freeze candidates get high-mode audits
+before freezing (the freeze itself stays standard-mode median-of-3). Building
+after would mean doing all of that by hand once more, then automating it.
 
-The 1.2 post-freeze FP sweep (one independent cross-model reviewer per target)
-found **zero detector false positives** but a recurring **remit-authoring
-over-reach** class — fabricated obligations, heading-as-rule extraction, and
-MUST-NOTs that contradict documented features. Fixed + re-frozen on 6 targets
-during 1.2; deferred on the rest. The durable fix is generation-side — do it
-**before** re-scanning the deferred targets, not by hand-editing each remit.
+## Contents
 
-- **#198** — remit generator authors well-formed, docs-grounded, non-over-reaching
-  statements (heading-as-rule + fabrication/over-scope). **The durable fix — first.**
-- **#201** (helperbot, craftbot, autogen, uagents) + **#200** (aider) — remit
-  over-reach cleanup on the targets still carrying it; regenerate on the
-  #198-improved generator, then re-scan + re-freeze. (The helperbot showcase
-  example carries this over-reach too — it refreshes with the re-freeze.)
-- **#195** — sharpen RAISE category band anchors (band-edge variance on
-  mid-maturity targets; drove the autogen/uagents wide bands).
-- **#196** — tighten the Step-8.5 fold-vs-break-out decomposition rule
-  (finding-count variance). Same axis as #48 and the decomposition-independence
-  generalization below — land them together.
-- **#197** — Thinking Modes: opt-in high-fidelity accuracy tiers. **Designed
-  2026-08-10 — see `plans/DESIGN_THINKING_MODES.md`** (evidence-adjudicated,
-  not consensus-counted; scores re-derived, never blended). User-facing; no
-  baseline impact — may ship as a satellite ahead of the freeze.
+1. **#197 — Thinking Modes v1**, exactly per `DESIGN_THINKING_MODES.md`:
+   `THINKING_MODES.md` mode instructions (separate file; SKILL.md gets only a
+   gate-scanned pointer), high-mode pipeline (audit brief, three-way verdicts,
+   cleanup + re-render), x-high pipeline (3× scan, union + matching with
+   `scan_diff.py` assist, adjudication, super-run assembly), adjudication +
+   variance artifacts, harness isolation docs (Claude Code subagents; Codex
+   `fork_turns="none"` sub-agents — verify isolation empirically per design
+   §7; fresh-session recipe for any other harness), user docs incl. the cost
+   table.
+2. **#226 leftovers** *(rider — docs-only)*: the verified list on the issue —
+   quickstart `PRAX-005` fake ID, llms.txt Codex mention, spec "four files"
+   undercount, duplicated "Working with Praxen", plus verify items 10/13
+   either way.
+3. **#151 Google Antigravity harness** *(optional rider — packaging/docs
+   only, engine unchanged)*: pull in if convenient; an external contact is
+   waiting. Dropping it to 1.4 needs no plan amendment.
 
-## Carried from the 1.2 Stage-1 gate — decomposition-independence generalization
+Scope fence, restated from the design: **if this release grows a schema
+field, a template change, or any standard-path behavior change, it is no
+longer freeze-independent and loses its slot ahead of 1.4.** The `scan_mode`
+provenance field is explicitly deferred to ride a re-baseline with #118.
 
-The 1.2 Stage-1 gate (`tests/runs/v1.2-stage1-gate/GATE.md`) fixed the
-**compound-contributor** decomposition variance (the fold/break-out decidability
-test — uAgents 9/10/13 → 9/8/8). It left one residual: helperbot's `8/6/8`
-spread, whose low outlier **merged two independently-material findings** (a
-config-disclosure behavior gap and a hardcoded-secret-in-prompt gap) into one.
-That is the *same* independence principle applied in the other direction — the
-current rule governs fold-vs-breakout for compound contributors but not
-merge-vs-separate for independent findings.
+## Gates
 
-**Work item (Stage 3, with #48):** promote the independence/decidability test to
-*the* single decomposition principle, stated once, governing **both** directions
-— *two things are separate findings iff each would still be a finding after the
-other is fixed*. This is squarely #48's axis (decomposition/materiality
-determinism) and belongs where (a) the **hand-score anchor** defines the *correct*
-decomposition, and (b) the **full re-baseline** measures the rule across all 12
-targets — not bolted onto Stage 1 under-validated (it's a core rule with
-suite-wide blast radius). The rest of helperbot's residual (`enp` on
-advertised-but-unwired tools; wildcard-CORS materiality on a training target) is
-genuine judgment, not rule-forceable — leave it to the hand-score calibration.
+- **Standard-mode non-regression:** byte-identical renders (existing CI gate)
+  + a blind standard-mode gate scan of a baseline target lands in-band (the
+  #216 treatment, for the SKILL.md pointer line).
+- **Design acceptance §9:** high mode independently reproduces the 1.2
+  human-scrub catches (scrub reports are ground truth; hand spot-check every
+  UNSUPPORTED verdict on first runs); an x-high super-run *pair* on a
+  historically wide-band target (autogen or uAgents) holds finding sets
+  near-identical with score delta well inside the historical single-run band;
+  no unmatched duplicates in x-high output.
 
-## Buckets
+## Release mechanics
 
-### A · Detection additions *(the re-baseline justification — land all before the freeze)*
+Standard flow (per `feedback_dev_main_branching` + the 1.2.1 record): work on
+a feature branch → squash to `dev` → promotion PR (merge commit, FF `dev`) →
+tag `v1.3.0` → post-tag sandboxed install smoke (must report 1.3.0) + a
+fresh-agent scan check → blog post ("Praxen 1.3: Thinking Modes" — the
+feature is the story). Bump reminders: `bump_version.py --dry-run` first;
+re-run `tests/render/render_all_remits.py` after the bump (remits stamp the
+version at render time — the de-facto seventh surface); ride the
+`v1.2.1+` install-confirm floors forward.
 
-- **#65 item 4** — IaC/deployment artifacts as first-class Step-4 discovery
-  surfaces (Helm values, K8s manifests, Terraform, docker-compose). The
-  uAgents committed-Helm-seed Critical was found by manual luck; this makes it
-  systematic. Cheap, high-yield.
-- **#41** — named detection pattern: external API response → filesystem write
-  (path-traversal class; the missed Hermes CVE-2026-7396 is the proof case).
-- **#104** — entropy-based secret detection in `render.py`'s redaction
-  backstop (catch high-entropy credentials the pattern list doesn't know).
+## Non-goals
 
-### B · Coverage & roster
-
-- **#70 (retitled in 1.1.1)** — replace the retired DB/NL-to-SQL archetype
-  with a live SQL-agent target, or explicitly accept the gap and close. The
-  only roster archetype dropped un-replaced in 1.0.2.
-- **LLM05 specialist target** — downgraded from "known gap" to nice-to-have
-  after 1.1 recovered LLM05 on existing targets (4P/6S); add only if a strong
-  live candidate appears.
-- **`scan_type: framework` (#65 item 5)** — `deployed_agent | framework | sdk`
-  in the remit identity table; report framing + scoring guidance acknowledge
-  operator-configurable defaults. **Gated on the O5 decision** (ported here from
-  the archived `plans/PHASE1_OPEN_ISSUES.md` — the question, verbatim: *uAgents
-  is a framework/library, not a single deployed agent; Phase 1 analyzed the
-  framework's own runtime posture/defaults. Confirm this framing is what we want
-  (vs. scanning a specific example agent built on it)* — one operator paragraph,
-  needed regardless.
-- **Directional-lean correction** — only if 1.2's anchored check dispositioned
-  it as structural-but-uncorrected; otherwise strike.
-
-### C · Output quality & report UX *(no scan-behavior change)*
-
-- **#113** — wrap technical tokens in `<code>` consistently across prose
-  fields *(model-output change — schedule before the freeze, with bucket A)*.
-- ~~**#27** — finding default-state (collapsed/expanded) + expand/collapse-all.~~
-  **Deferred indefinitely** (Steve, 2026-08-05, during 1.2.1: *"Defer [#27]
-  indefinitely, but leave it filed - don't close"*) — not scheduled here or
-  anywhere; the open issue is the record.
-- ~~**#6 remainder** — render polish: finding-card confidence, Medium/Low badge.~~
-  **Done in 1.2.1** (finding-card confidence line shipped; Medium/Low→ADVISORY
-  collapse documented as intentional; the TXT item had shipped in 1.0.1).
-- **#25** — split output-authoring conventions out of `SKILL.md`
-  (rendering/MVC split). Refactor only; no output change.
-
-### D · Harness reach & docs *(no baseline impact — may ship earlier as 1.2.x satellites)*
-
-- **#151** — Google Antigravity (`agy` CLI) harness: packaging + docs only,
-  engine unchanged. An external contact is waiting; there is no engineering
-  reason this must wait for 1.3 — pull forward whenever convenient.
-- ~~**#65 items 6–7** — code-first warning block, mechanism-vs-property rule
-  note.~~ **Done in 1.2.1.** **#65 item 8** (absence-of-evidence confidence
-  calibration in `KB_RAISE_SCANNING.md`) does **not** belong in this bucket:
-  that KB is scanner-read primary calibration — **it can move scores** (per the
-  1.2.1 plan's own exclusion) — so it rides **pre-freeze with bucket A**.
-  **#65 item 3** (25-word summary cap breaks down for compound findings) is
-  model-output prose — schedule with #113, pre-freeze.
-- ~~**#106** — Out-of-Scope coverage as boundary-rule checks.~~ **Done in 1.2.1.**
-- **#226 leftovers** — docs batch starting from the verified status list on the
-  issue (quickstart's `PRAX-005` fake ID; llms.txt has no Codex mention; spec
-  §"four files" undercount; duplicated "Working with Praxen"; items 10/13
-  unverified either way). Docs-only, no baseline impact.
-- **#117** — challenging-findings.md additions (gated on #118; collapses to a
-  one-paragraph note if #118 isn't adopted) · **#118** operator override +
-  finding-revision records (schema-contract change — if adopted, it must ride
-  a re-baseline release, this one or later) · ~~**#135** docs simplicity pass ·
-  **#4** SKILL authoring aids~~ *(both done in 1.2.1)* · **#90** shared org
-  design system · **#2** standing config *(still explicitly deferred)* ·
-  **#217** manifest-authoring tooling assist *(robustness RFE — partially
-  mitigated by the mid-draft `--validate-manifest` flow; unscheduled, keep on
-  the radar)*.
-
-## Sequencing
-
-A + #113 + #65 items 3/8 (everything that changes findings, scoring calibration,
-or model prose) → C/D in any order → **one re-freeze `v1.3-opus5`, last.** Same
-discipline as 1.2: nothing that moves numbers lands after the freeze; a stressed
-schedule drops whole buckets by dated plan amendment, not by silent descope.
-
-Release mechanics (learned in 1.2.1): the version bump must be followed by
-`tests/render/render_all_remits.py` — remit HTMLs stamp the version from
-`plugin.json` at render time, a de-facto seventh version surface (analysis
-reports are immune; they stamp `praxen_version` from the findings JSON). The
-docs tripwire will also flag the `v1.2.1+` install-confirm floors — ride them
-forward. `bump_version.py --dry-run` first; it is still not CI-exercised.
-
-## Success metric (first cut — re-triage at 1.2 freeze)
-
-- **Detection:** each bucket-A pattern demonstrated on its proof case (Helm
-  seed class, path-traversal class, entropy-caught secret) in the frozen set
-  or a fixture.
-- **Coverage:** the #70 decision executed (target added and characterized
-  median-of-3, or gap formally accepted); coverage pages regenerated with no
-  undocumented zero columns (P+S counting, per the 1.2 rule).
-- **Stability holds:** the 1.2 gates re-pass on the 1.3 stack — zero watchdog
-  deaths on the freeze runs; calibration-target |drift| ≤ 0.2 vs
-  `v1.2-opus5`. New detection must not cost the reliability and scoring
-  stability 1.2 just bought.
+No detection changes, no scoring-rubric changes, no remit regeneration, no
+roster changes, no re-freeze — all of that is 1.4. If a mode implementation
+detail turns out to require a scoring or schema change, it stops, gets logged
+on #197, and waits.

--- a/plans/RELEASE_1.3_PLAN.md
+++ b/plans/RELEASE_1.3_PLAN.md
@@ -9,19 +9,20 @@
 > the 1.2 close-out (2026-07-30)** now that 1.2 has frozen (shipped to `dev`).
 > Holds everything cut from 1.2, plus what 1.2 pushed (#48) or newly surfaced (the
 > remit-generator / over-reach class below). **Reference model is now Opus 5** —
-> 1.3 grades vs **`v1.2-opus5`**, not `v1.2-claude48`. Branches from `dev` after
-> the 1.2 → main promotion.
+> 1.3 grades vs **`v1.2-opus5`**, not `v1.2-claude48`.
 >
-> **`v1.2.0` shipped 2026-08-03.** A score-inert patch, **`RELEASE_1.2.1_PLAN.md`**,
-> is drafted ahead of this release for the docs/CI tail from the promotion reviews
-> — anything that moves a number stayed here. If 1.2.1 ships first, 1.3 branches
-> from `dev` after it.
+> **`v1.2.0` shipped 2026-08-03; `v1.2.1` shipped 2026-08-10** (score-inert, per
+> `RELEASE_1.2.1_PLAN.md` — now STATUS: SHIPPED). 1.2.1 absorbed the docs/CI tail
+> plus several items this plan had parked: **#106, #135, #4, #6 (complete, as a
+> linked confidence bubble), #65 items 6–7** — struck below. Anything that moves
+> a number stayed here. **1.3 branches from `dev` after the 1.2.1 promotion
+> (`c004640`).** Re-triaged at the 1.2.1 close-out, 2026-08-10.
 
 ## Objective
 
 With scans reliable and scores stable (1.2), widen what Praxen *finds* and
 polish what it *emits*. Detection additions move numbers → 1.3 re-freezes
-`v1.3-claude48`, graded vs `v1.2-claude48`. That freeze is why the detection
+**`v1.3-opus5`**, graded vs **`v1.2-opus5`**. That freeze is why the detection
 items travel together here rather than dribbling in: one release, one freeze.
 
 ## Arrived from 1.2 — #48 (Stage-2.5 PUSH — confirmed 2026-07-30)
@@ -132,27 +133,41 @@ genuine judgment, not rule-forceable — leave it to the hand-score calibration.
 - **#151** — Google Antigravity (`agy` CLI) harness: packaging + docs only,
   engine unchanged. An external contact is waiting; there is no engineering
   reason this must wait for 1.3 — pull forward whenever convenient.
-- **#65 items 6–8** — remit-authoring guidance: code-first warning block,
-  mechanism-vs-property rule note in the remit template, absence-of-evidence
-  confidence calibration in `KB_RAISE_SCANNING.md`. *(Item 6–8 wording changes
-  what remit authors write, not what the scanner scores against committed
-  remits — safe outside the freeze.)*
-- **#106** — clarify Out-of-Scope remit coverage as boundary-rule checks (remit
-  coverage semantics; authoring-side, no scan-behavior change). Sits with the
-  remit-authoring guidance above and the #198 generator work.
+- ~~**#65 items 6–7** — code-first warning block, mechanism-vs-property rule
+  note.~~ **Done in 1.2.1.** **#65 item 8** (absence-of-evidence confidence
+  calibration in `KB_RAISE_SCANNING.md`) does **not** belong in this bucket:
+  that KB is scanner-read primary calibration — **it can move scores** (per the
+  1.2.1 plan's own exclusion) — so it rides **pre-freeze with bucket A**.
+  **#65 item 3** (25-word summary cap breaks down for compound findings) is
+  model-output prose — schedule with #113, pre-freeze.
+- ~~**#106** — Out-of-Scope coverage as boundary-rule checks.~~ **Done in 1.2.1.**
+- **#226 leftovers** — docs batch starting from the verified status list on the
+  issue (quickstart's `PRAX-005` fake ID; llms.txt has no Codex mention; spec
+  §"four files" undercount; duplicated "Working with Praxen"; items 10/13
+  unverified either way). Docs-only, no baseline impact.
 - **#117** — challenging-findings.md additions (gated on #118; collapses to a
   one-paragraph note if #118 isn't adopted) · **#118** operator override +
   finding-revision records (schema-contract change — if adopted, it must ride
-  a re-baseline release, this one or later) · **#135** docs simplicity pass ·
-  **#4** SKILL authoring aids · **#90** shared org design system · **#2**
-  standing config *(still explicitly deferred)*.
+  a re-baseline release, this one or later) · ~~**#135** docs simplicity pass ·
+  **#4** SKILL authoring aids~~ *(both done in 1.2.1)* · **#90** shared org
+  design system · **#2** standing config *(still explicitly deferred)* ·
+  **#217** manifest-authoring tooling assist *(robustness RFE — partially
+  mitigated by the mid-draft `--validate-manifest` flow; unscheduled, keep on
+  the radar)*.
 
 ## Sequencing
 
-A + #113 (everything that changes findings or model prose) → C/D in any order
-→ **one re-freeze `v1.3-claude48`, last.** Same discipline as 1.2: nothing
-that moves numbers lands after the freeze; a stressed schedule drops whole
-buckets by dated plan amendment, not by silent descope.
+A + #113 + #65 items 3/8 (everything that changes findings, scoring calibration,
+or model prose) → C/D in any order → **one re-freeze `v1.3-opus5`, last.** Same
+discipline as 1.2: nothing that moves numbers lands after the freeze; a stressed
+schedule drops whole buckets by dated plan amendment, not by silent descope.
+
+Release mechanics (learned in 1.2.1): the version bump must be followed by
+`tests/render/render_all_remits.py` — remit HTMLs stamp the version from
+`plugin.json` at render time, a de-facto seventh version surface (analysis
+reports are immune; they stamp `praxen_version` from the findings JSON). The
+docs tripwire will also flag the `v1.2.1+` install-confirm floors — ride them
+forward. `bump_version.py --dry-run` first; it is still not CI-exercised.
 
 ## Success metric (first cut — re-triage at 1.2 freeze)
 
@@ -164,5 +179,5 @@ buckets by dated plan amendment, not by silent descope.
   undocumented zero columns (P+S counting, per the 1.2 rule).
 - **Stability holds:** the 1.2 gates re-pass on the 1.3 stack — zero watchdog
   deaths on the freeze runs; calibration-target |drift| ≤ 0.2 vs
-  `v1.2-claude48`. New detection must not cost the reliability and scoring
+  `v1.2-opus5`. New detection must not cost the reliability and scoring
   stability 1.2 just bought.

--- a/plans/RELEASE_1.4_PLAN.md
+++ b/plans/RELEASE_1.4_PLAN.md
@@ -1,0 +1,191 @@
+<!--
+  Copyright 2026 Exabeam, Inc.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Praxen 1.4 — Detection Coverage, Output Quality & Reach
+
+> **Formerly `RELEASE_1.3_PLAN.md` — renumbered 2026-08-10** when Thinking Modes
+> (#197) was promoted to its own minor release ahead of this one: **1.3 = the
+> accuracy release** (`RELEASE_1.3_PLAN.md`, per `DESIGN_THINKING_MODES.md`),
+> **1.4 = this detection/re-baseline release**. Historical references to "the 1.3
+> plan" in earlier release plans point at this document's content.
+>
+> Drafted 2026-07-15 alongside the revised `RELEASE_1.2_PLAN.md`; **re-triaged at
+> the 1.2 close-out (2026-07-30)** now that 1.2 has frozen (shipped to `dev`).
+> Holds everything cut from 1.2, plus what 1.2 pushed (#48) or newly surfaced (the
+> remit-generator / over-reach class below). **Reference model is now Opus 5** —
+> 1.4 grades vs **`v1.2-opus5`**, not `v1.2-claude48` (1.3 is score-inert by
+> construction and freezes nothing, so `v1.2-opus5` remains the current set).
+>
+> **`v1.2.0` shipped 2026-08-03; `v1.2.1` shipped 2026-08-10** (score-inert, per
+> `RELEASE_1.2.1_PLAN.md` — now STATUS: SHIPPED). 1.2.1 absorbed the docs/CI tail
+> plus several items this plan had parked: **#106, #135, #4, #6 (complete, as a
+> linked confidence bubble), #65 items 6–7** — struck below. Anything that moves
+> a number stayed here. **1.4 branches from `dev` after the 1.3 promotion.**
+> Re-triaged at the 1.2.1 close-out, 2026-08-10.
+
+## Objective
+
+With scans reliable and scores stable (1.2), widen what Praxen *finds* and
+polish what it *emits*. Detection additions move numbers → 1.4 re-freezes
+**`v1.4-opus5`**, graded vs **`v1.2-opus5`**. That freeze is why the detection
+items travel together here rather than dribbling in: one release, one freeze.
+
+## Arrived from 1.2 — #48 (Stage-2.5 PUSH — confirmed 2026-07-30)
+
+1.2's Stage-2.5 decision was **PUSH**: the scoring rework was reverted to
+shipped-state (Steve, 2026-07-28 — the headline pivoted to OWASP 2026), so **#48
+lands here**, sequenced **before** bucket A's detection additions so its
+before/after grading window isn't contaminated by new findings. It rides this
+release's re-freeze at no extra freeze cost. The clean "before" is the frozen
+**`v1.2-opus5`** baseline (single-scan reproducibility is the target, on the
+Opus-5 stack); the earlier `tests/runs/v1.2-stage2.5/` characterization was on
+Opus 4.8 and is now historical only.
+
+## New from the 1.2 baseline experience — remit-generator quality & over-reach cleanup
+
+The 1.2 post-freeze FP sweep (one independent cross-model reviewer per target)
+found **zero detector false positives** but a recurring **remit-authoring
+over-reach** class — fabricated obligations, heading-as-rule extraction, and
+MUST-NOTs that contradict documented features. Fixed + re-frozen on 6 targets
+during 1.2; deferred on the rest. The durable fix is generation-side — do it
+**before** re-scanning the deferred targets, not by hand-editing each remit.
+
+- **#198** — remit generator authors well-formed, docs-grounded, non-over-reaching
+  statements (heading-as-rule + fabrication/over-scope). **The durable fix — first.**
+- **#201** (helperbot, craftbot, autogen, uagents) + **#200** (aider) — remit
+  over-reach cleanup on the targets still carrying it; regenerate on the
+  #198-improved generator, then re-scan + re-freeze. (The helperbot showcase
+  example carries this over-reach too — it refreshes with the re-freeze.)
+- **#195** — sharpen RAISE category band anchors (band-edge variance on
+  mid-maturity targets; drove the autogen/uagents wide bands).
+- **#196** — tighten the Step-8.5 fold-vs-break-out decomposition rule
+  (finding-count variance). Same axis as #48 and the decomposition-independence
+  generalization below — land them together.
+- ~~**#197** — Thinking Modes.~~ **Promoted out of this release entirely: ships
+  as release 1.3** (`RELEASE_1.3_PLAN.md` / `DESIGN_THINKING_MODES.md`),
+  deliberately **before** this one — so the #200/#201 re-scrubs run as
+  automated high-mode audits, and the x-high variance diagnostics feed
+  #48/#195/#196 here.
+
+## Carried from the 1.2 Stage-1 gate — decomposition-independence generalization
+
+The 1.2 Stage-1 gate (`tests/runs/v1.2-stage1-gate/GATE.md`) fixed the
+**compound-contributor** decomposition variance (the fold/break-out decidability
+test — uAgents 9/10/13 → 9/8/8). It left one residual: helperbot's `8/6/8`
+spread, whose low outlier **merged two independently-material findings** (a
+config-disclosure behavior gap and a hardcoded-secret-in-prompt gap) into one.
+That is the *same* independence principle applied in the other direction — the
+current rule governs fold-vs-breakout for compound contributors but not
+merge-vs-separate for independent findings.
+
+**Work item (Stage 3, with #48):** promote the independence/decidability test to
+*the* single decomposition principle, stated once, governing **both** directions
+— *two things are separate findings iff each would still be a finding after the
+other is fixed*. This is squarely #48's axis (decomposition/materiality
+determinism) and belongs where (a) the **hand-score anchor** defines the *correct*
+decomposition, and (b) the **full re-baseline** measures the rule across all 12
+targets — not bolted onto Stage 1 under-validated (it's a core rule with
+suite-wide blast radius). The rest of helperbot's residual (`enp` on
+advertised-but-unwired tools; wildcard-CORS materiality on a training target) is
+genuine judgment, not rule-forceable — leave it to the hand-score calibration.
+
+## Buckets
+
+### A · Detection additions *(the re-baseline justification — land all before the freeze)*
+
+- **#65 item 4** — IaC/deployment artifacts as first-class Step-4 discovery
+  surfaces (Helm values, K8s manifests, Terraform, docker-compose). The
+  uAgents committed-Helm-seed Critical was found by manual luck; this makes it
+  systematic. Cheap, high-yield.
+- **#41** — named detection pattern: external API response → filesystem write
+  (path-traversal class; the missed Hermes CVE-2026-7396 is the proof case).
+- **#104** — entropy-based secret detection in `render.py`'s redaction
+  backstop (catch high-entropy credentials the pattern list doesn't know).
+
+### B · Coverage & roster
+
+- **#70 (retitled in 1.1.1)** — replace the retired DB/NL-to-SQL archetype
+  with a live SQL-agent target, or explicitly accept the gap and close. The
+  only roster archetype dropped un-replaced in 1.0.2.
+- **LLM05 specialist target** — downgraded from "known gap" to nice-to-have
+  after 1.1 recovered LLM05 on existing targets (4P/6S); add only if a strong
+  live candidate appears.
+- **`scan_type: framework` (#65 item 5)** — `deployed_agent | framework | sdk`
+  in the remit identity table; report framing + scoring guidance acknowledge
+  operator-configurable defaults. **Gated on the O5 decision** (ported here from
+  the archived `plans/PHASE1_OPEN_ISSUES.md` — the question, verbatim: *uAgents
+  is a framework/library, not a single deployed agent; Phase 1 analyzed the
+  framework's own runtime posture/defaults. Confirm this framing is what we want
+  (vs. scanning a specific example agent built on it)* — one operator paragraph,
+  needed regardless.
+- **Directional-lean correction** — only if 1.2's anchored check dispositioned
+  it as structural-but-uncorrected; otherwise strike.
+
+### C · Output quality & report UX *(no scan-behavior change)*
+
+- **#113** — wrap technical tokens in `<code>` consistently across prose
+  fields *(model-output change — schedule before the freeze, with bucket A)*.
+- ~~**#27** — finding default-state (collapsed/expanded) + expand/collapse-all.~~
+  **Deferred indefinitely** (Steve, 2026-08-05, during 1.2.1: *"Defer [#27]
+  indefinitely, but leave it filed - don't close"*) — not scheduled here or
+  anywhere; the open issue is the record.
+- ~~**#6 remainder** — render polish: finding-card confidence, Medium/Low badge.~~
+  **Done in 1.2.1** (finding-card confidence line shipped; Medium/Low→ADVISORY
+  collapse documented as intentional; the TXT item had shipped in 1.0.1).
+- **#25** — split output-authoring conventions out of `SKILL.md`
+  (rendering/MVC split). Refactor only; no output change.
+
+### D · Harness reach & docs *(no baseline impact — may ship earlier as 1.2.x satellites)*
+
+- **#151** — Google Antigravity (`agy` CLI) harness: packaging + docs only,
+  engine unchanged. An external contact is waiting; there is no engineering
+  reason this must wait for 1.4 — pull forward whenever convenient (a ride
+  on the 1.3 satellite is the natural slot).
+- ~~**#65 items 6–7** — code-first warning block, mechanism-vs-property rule
+  note.~~ **Done in 1.2.1.** **#65 item 8** (absence-of-evidence confidence
+  calibration in `KB_RAISE_SCANNING.md`) does **not** belong in this bucket:
+  that KB is scanner-read primary calibration — **it can move scores** (per the
+  1.2.1 plan's own exclusion) — so it rides **pre-freeze with bucket A**.
+  **#65 item 3** (25-word summary cap breaks down for compound findings) is
+  model-output prose — schedule with #113, pre-freeze.
+- ~~**#106** — Out-of-Scope coverage as boundary-rule checks.~~ **Done in 1.2.1.**
+- ~~**#226 leftovers** — docs batch.~~ **Moved to the 1.3 satellite**
+  (`RELEASE_1.3_PLAN.md`) — docs-only cargo rides the earlier release.
+- **#117** — challenging-findings.md additions (gated on #118; collapses to a
+  one-paragraph note if #118 isn't adopted) · **#118** operator override +
+  finding-revision records (schema-contract change — if adopted, it must ride
+  a re-baseline release, this one or later) · ~~**#135** docs simplicity pass ·
+  **#4** SKILL authoring aids~~ *(both done in 1.2.1)* · **#90** shared org
+  design system · **#2** standing config *(still explicitly deferred)* ·
+  **#217** manifest-authoring tooling assist *(robustness RFE — partially
+  mitigated by the mid-draft `--validate-manifest` flow; unscheduled, keep on
+  the radar)*.
+
+## Sequencing
+
+A + #113 + #65 items 3/8 (everything that changes findings, scoring calibration,
+or model prose) → C/D in any order → **one re-freeze `v1.4-opus5`, last.** Same
+discipline as 1.2: nothing that moves numbers lands after the freeze; a stressed
+schedule drops whole buckets by dated plan amendment, not by silent descope.
+
+Release mechanics (learned in 1.2.1): the version bump must be followed by
+`tests/render/render_all_remits.py` — remit HTMLs stamp the version from
+`plugin.json` at render time, a de-facto seventh version surface (analysis
+reports are immune; they stamp `praxen_version` from the findings JSON). The
+docs tripwire will also flag the `v1.2.1+` install-confirm floors — ride them
+forward. `bump_version.py --dry-run` first; it is still not CI-exercised.
+
+## Success metric (first cut — re-triage at 1.2 freeze)
+
+- **Detection:** each bucket-A pattern demonstrated on its proof case (Helm
+  seed class, path-traversal class, entropy-caught secret) in the frozen set
+  or a fixture.
+- **Coverage:** the #70 decision executed (target added and characterized
+  median-of-3, or gap formally accepted); coverage pages regenerated with no
+  undocumented zero columns (P+S counting, per the 1.2 rule).
+- **Stability holds:** the 1.2 gates re-pass on the 1.4 stack — zero watchdog
+  deaths on the freeze runs; calibration-target |drift| ≤ 0.2 vs
+  `v1.2-opus5`. New detection must not cost the reliability and scoring
+  stability 1.2 just bought.


### PR DESCRIPTION
Plans-only promotion so the public plan set is accurate before 1.3 branches:

- `RELEASE_1.2.1_PLAN.md` → STATUS: SHIPPED (v1.2.1, 2026-08-10)
- **Thinking Modes designed** (`DESIGN_THINKING_MODES.md`, #197) and promoted to its own minor release: **1.3 = the accuracy release** (new slim `RELEASE_1.3_PLAN.md`), shipping before the detection/re-baseline release, which renumbered to **1.4** (`RELEASE_1.4_PLAN.md`, formerly the 1.3 plan — carries a 'formerly' note; freeze renamed `v1.4-opus5`)
- 1.4 plan re-triaged at the 1.2.1 close-out (absorbed items struck, stale claude48 freeze naming fixed, #65 item 8 relocated pre-freeze, bump lessons recorded)

No code, docs/, skill, schema, or render changes — `plans/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)