### PR TITLE
news: add Pazmiño Ortiz and Eva Benn community commentary

### DIFF
--- a/news.html
+++ b/news.html
@@ -333,6 +333,11 @@
       <div class="wrap">
         <h2>Industry commentary</h2>
         <div class="cov-grid">
+          <a class="cov-card" href="https://www.linkedin.com/posts/lpazminoortiz_aisecurity-agenticai-aiagents-share-7492280085392130050-hQ8t/" target="_blank" rel="noopener">
+            <div class="cov-outlet">Leandro Pazmiño Ortiz · LinkedIn</div>
+            <p class="cov-title">4 Open-Source Tools to Secure AI Agents — Praxen named the behavior-verification layer of an emerging "AI Agent Security Stack," checking declared policy against code, configuration, logs, and governance docs to catch capability drift</p>
+            <span class="cov-read">Read →</span>
+          </a>
           <a class="cov-card" href="https://open-agent-ai-security.github.io/blog/praxen-scan-earns-keep/" target="_blank" rel="noopener">
             <div class="cov-outlet">Open Agent AI Security · Community Blog</div>
             <p class="cov-title">When a Security Scan Earns Its Keep — a developer ran Praxen against a security-sensitive agent codebase: a data-exposure gap in diagnostic exports, unsafe tool descriptions, and unescaped third-party text in a privileged instruction channel, all found and fixed the same day</p>

--- a/news.html
+++ b/news.html
@@ -338,6 +338,11 @@
             <p class="cov-title">4 Open-Source Tools to Secure AI Agents — Praxen named the behavior-verification layer of an emerging "AI Agent Security Stack," checking declared policy against code, configuration, logs, and governance docs to catch capability drift</p>
             <span class="cov-read">Read →</span>
           </a>
+          <a class="cov-card" href="https://www.instagram.com/reel/DbVz7miSRYC/" target="_blank" rel="noopener">
+            <div class="cov-outlet">Eva Benn (@evabennofficial) · Instagram</div>
+            <p class="cov-title">4 Free Tools to Secure AI Agents — Praxen featured in the cybersecurity keynote speaker's weekly practical-resources series (video reel)</p>
+            <span class="cov-read">Watch →</span>
+          </a>
           <a class="cov-card" href="https://open-agent-ai-security.github.io/blog/praxen-scan-earns-keep/" target="_blank" rel="noopener">
             <div class="cov-outlet">Open Agent AI Security · Community Blog</div>
             <p class="cov-title">When a Security Scan Earns Its Keep — a developer ran Praxen against a security-sensitive agent codebase: a data-exposure gap in diagnostic exports, unsafe tool descriptions, and unescaped third-party text in a privileged instruction channel, all found and fixed the same day</p>


### PR DESCRIPTION
Two additions to the top of **Industry commentary** on the praxen news page:

1. [Leandro Pazmiño Ortiz's LinkedIn post](https://www.linkedin.com/posts/lpazminoortiz_aisecurity-agenticai-aiagents-share-7492280085392130050-hQ8t/) — "4 Open-Source Tools to Secure AI Agents" — naming Praxen the behavior-verification layer of an emerging "AI Agent Security Stack" (alongside OWASP Agent Memory Guard, Agent Threat Rules, and Agent Beacon).
2. [Eva Benn's Instagram reel](https://www.instagram.com/reel/DbVz7miSRYC/) — "4 free tools to secure AI agents" from her weekly practical-cybersecurity-resources series, featuring Praxen (video; caption doesn't list the tools, card wording kept conservative).

The "10+ community voices" topline stat still holds (now 13 cards), so no counter change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)