### PR TITLE
docs: adopt GCC-style known-identity wording for DCO sign-off

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,10 @@ Git adds it for you with the `-s` flag:
 git commit -s -m "Your commit message"
 ```
 
-The name and email must match a real identity (no anonymous or pseudonymous
-contributions). A CI check (`.github/workflows/dco.yml`) verifies every non-merge
+The name and email must be a known identity — your real name, or an established
+identity you're known by in the community (a long-standing handle counts),
+reachable at the address you sign with. Anonymous or throwaway identities aren't
+accepted. A CI check (`.github/workflows/dco.yml`) verifies every non-merge
 commit in a pull request carries a `Signed-off-by` line matching the author or
 committer; PRs that don't pass will be asked to amend before merge.
 


### PR DESCRIPTION
Replaces the "real identity (no anonymous or pseudonymous contributions)" sentence in CONTRIBUTING.md with GCC-style known-identity language: a legal name **or** an established, contactable community identity; anonymous/throwaway contributions remain excluded.

Rationale (from the consultant follow-up review): the old wording promised more provenance than the DCO CI can verify, and as written it barred long-established professional handles — a real population in the security community — while admitting throwaway accounts with plausible-looking names. Kernel and GCC precedent both use the known-identity standard.

Same sentence is landing in observra, promptfall, and socxen so all four repos match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)