### PR TITLE
Promote news cards + DCO known-identity wording to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,10 @@ Git adds it for you with the `-s` flag:
 git commit -s -m "Your commit message"
 ```
 
-The name and email must match a real identity (no anonymous or pseudonymous
-contributions). A CI check (`.github/workflows/dco.yml`) verifies every non-merge
+The name and email must be a known identity — your real name, or an established
+identity you're known by in the community (a long-standing handle counts),
+reachable at the address you sign with. Anonymous or throwaway identities aren't
+accepted. A CI check (`.github/workflows/dco.yml`) verifies every non-merge
 commit in a pull request carries a `Signed-off-by` line matching the author or
 committer; PRs that don't pass will be asked to amend before merge.
 

--- a/news.html
+++ b/news.html
@@ -333,6 +333,16 @@
       <div class="wrap">
         <h2>Industry commentary</h2>
         <div class="cov-grid">
+          <a class="cov-card" href="https://www.linkedin.com/posts/lpazminoortiz_aisecurity-agenticai-aiagents-share-7492280085392130050-hQ8t/" target="_blank" rel="noopener">
+            <div class="cov-outlet">Leandro Pazmiño Ortiz · LinkedIn</div>
+            <p class="cov-title">4 Open-Source Tools to Secure AI Agents — Praxen named the behavior-verification layer of an emerging "AI Agent Security Stack," checking declared policy against code, configuration, logs, and governance docs to catch capability drift</p>
+            <span class="cov-read">Read →</span>
+          </a>
+          <a class="cov-card" href="https://www.instagram.com/reel/DbVz7miSRYC/" target="_blank" rel="noopener">
+            <div class="cov-outlet">Eva Benn (@evabennofficial) · Instagram</div>
+            <p class="cov-title">4 Free Tools to Secure AI Agents — Praxen featured in the cybersecurity keynote speaker's weekly practical-resources series (video reel)</p>
+            <span class="cov-read">Watch →</span>
+          </a>
           <a class="cov-card" href="https://open-agent-ai-security.github.io/blog/praxen-scan-earns-keep/" target="_blank" rel="noopener">
             <div class="cov-outlet">Open Agent AI Security · Community Blog</div>
             <p class="cov-title">When a Security Scan Earns Its Keep — a developer ran Praxen against a security-sensitive agent codebase: a data-exposure gap in diagnostic exports, unsafe tool descriptions, and unescaped third-party text in a privileged instruction channel, all found and fixed the same day</p>


### PR DESCRIPTION
Docs/news-only promotion:

- **#244** — two Industry-commentary cards on news.html (Pazmiño Ortiz LinkedIn post, Eva Benn Instagram reel)
- **#245** — GCC-style known-identity wording for the DCO sign-off in CONTRIBUTING.md

No product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)