### PR TITLE
docs: close the #226 leftovers (1.3 docs rider)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,7 @@ Each finding is tagged against the **OWASP Top 10 for LLM Applications 2026**, *
 
 ## Working with Praxen
 
-Praxen produces an **expert review that focuses human attention.** Each report is a model-assisted analysis of where an agent's behavior may diverge from its remit. Treat the findings and RAISE maturity score as judgments to act on — a senior reviewer's notes, not an automated pass/fail. Scores are calibrated per model tier and vary run to run ([details](docs/understanding-variability.md)), and you can [challenge and revise any finding](docs/challenging-findings.md).
-
-Praxen works by **reading your agent's real workspace in place** — its actual code, config, and logs. It writes findings only to `./reports/` and never modifies the agent. It runs as a skill inside your coding agent, using that agent's own tools rather than a separate sandbox, so run Praxen where you already trust that agent to operate. The [security model and assumptions](SECURITY.md#security-model-and-assumptions) covers this in full.
+Praxen produces an **expert review that focuses human attention** — a senior reviewer's notes, not an automated pass/fail — and it works by **reading your agent's real workspace in place**, writing findings only to `./reports/` and never modifying the agent. How to treat the scores, run-to-run variability, and the [security model](SECURITY.md#security-model-and-assumptions) are covered in [Working with Praxen](docs/index.md#working-with-praxen) in the docs.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Praxen runs as a skill *inside* your coding agent (Claude Code, OpenAI Codex, or
 - **Read-only by convention, not by isolation.** Praxen is designed to operate read-only on the agent's workspace: it reads artifacts (code, config, logs, governance docs) and writes output only to its own `./reports/` directory. It does not act on the agent's behalf and does not modify the agent's code, skill files, configuration, or dependencies. But this is a **behavioral contract of the skill's instructions, not a technical sandbox** — Praxen runs with the coding agent's ordinary tool access (including Bash and Write), so the read-only posture is enforced by convention rather than by an isolation boundary. (This is the same declared-versus-enforced distinction Praxen itself flags when it scans other agents.) Run Praxen only where you already trust the coding agent to operate.
 - **Local by default.** Reports are written locally to `./reports/` (HTML, JSON, text). Nothing phones home.
 
-For guidance on interpreting Praxen's *output* — a model-assisted expert review rather than a deterministic gate — see [Working with Praxen](README.md#working-with-praxen).
+For guidance on interpreting Praxen's *output* — a model-assisted expert review rather than a deterministic gate — see [Working with Praxen](docs/index.md#working-with-praxen).
 
 ## Scope
 

--- a/docs/challenging-findings.md
+++ b/docs/challenging-findings.md
@@ -49,7 +49,7 @@ If the finding misreads the code, miscategorizes the issue, or asserts a chain t
 
 3. **Tighten the input.** If the evidence directory contains noise (test fixtures with deliberate vulnerabilities, archived old code, vendored dependencies), exclude it. Praxen will reason more sharply over a focused workspace.
 
-4. **If the issue persists across runs**, the analysis methodology may have a calibration bug. File it through whatever channel the project's release notes name. Include the finding ID, the cited evidence, what's actually in the code, and what you believe the correct severity (or absence of finding) should be.
+4. **If the issue persists across runs**, the analysis methodology may have a calibration bug. Please [file it](https://github.com/open-agent-ai-security/praxen/issues/new/choose). Include the finding ID, the cited evidence, what's actually in the code, and what you believe the correct severity (or absence of finding) should be.
 
 Do not edit the JSON or HTML output to "correct" the finding — those are the analysis artifacts and downstream consumers depend on them being unedited.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -98,7 +98,7 @@ Praxen reads the evidence, evaluates it against the RAISE Framework and the Work
 | `<agent-slug>-findings-<date>.json` | Machine-readable findings. Use for automation, ticketing, dashboards, diffing across runs. |
 | `<agent-slug>-analysis-<timestamp>.txt` | Plain-text summary suitable for terminal output, email body, or Slack message. |
 
-The findings JSON is keyed by **date** (`<YYYY-MM-DD>` — one per agent per day); the HTML and TXT carry a full **per-run timestamp** (`<YYYY-MM-DD-HHMMSS>`), so re-running the same day keeps each report distinct. Praxen also writes a working `<agent-slug>-draft-<timestamp>.md` checkpoint during the run — a recovery artifact, not a deliverable, and safe to delete.
+The findings JSON is keyed by **date** (`<YYYY-MM-DD>` — one per agent per day); the HTML and TXT carry a full **per-run timestamp** (`<YYYY-MM-DD-HHMMSS>`), so re-running the same day keeps each report distinct. Praxen also writes two working artifacts during the run — a `<agent-slug>-evidence-<timestamp>.txt` evidence checkpoint and a `<agent-slug>-draft-<timestamp>.md` draft manifest. Both are recovery artifacts, not deliverables, and safe to delete after the run.
 
 The `.txt` summary is also printed to stdout during the analysis, so you can read it as the run completes.
 

--- a/guide/challenging-findings.html
+++ b/guide/challenging-findings.html
@@ -322,7 +322,7 @@ img { max-width: 100%; display: block; }
 <p><strong>Tighten the input.</strong> If the evidence directory contains noise (test fixtures with deliberate vulnerabilities, archived old code, vendored dependencies), exclude it. Praxen will reason more sharply over a focused workspace.</p>
 </li>
 <li>
-<p><strong>If the issue persists across runs</strong>, the analysis methodology may have a calibration bug. File it through whatever channel the project's release notes name. Include the finding ID, the cited evidence, what's actually in the code, and what you believe the correct severity (or absence of finding) should be.</p>
+<p><strong>If the issue persists across runs</strong>, the analysis methodology may have a calibration bug. Please <a href="https://github.com/open-agent-ai-security/praxen/issues/new/choose">file it</a>. Include the finding ID, the cited evidence, what's actually in the code, and what you believe the correct severity (or absence of finding) should be.</p>
 </li>
 </ol>
 <p>Do not edit the JSON or HTML output to "correct" the finding — those are the analysis artifacts and downstream consumers depend on them being unedited.</p>

--- a/guide/usage.html
+++ b/guide/usage.html
@@ -368,7 +368,7 @@ against ./my-agent-repo/. Worker Remit is at ./WORKER_REMIT.md. Output to
 </tr>
 </tbody>
 </table>
-<p>The findings JSON is keyed by <strong>date</strong> (<code>&lt;YYYY-MM-DD&gt;</code> — one per agent per day); the HTML and TXT carry a full <strong>per-run timestamp</strong> (<code>&lt;YYYY-MM-DD-HHMMSS&gt;</code>), so re-running the same day keeps each report distinct. Praxen also writes a working <code>&lt;agent-slug&gt;-draft-&lt;timestamp&gt;.md</code> checkpoint during the run — a recovery artifact, not a deliverable, and safe to delete.</p>
+<p>The findings JSON is keyed by <strong>date</strong> (<code>&lt;YYYY-MM-DD&gt;</code> — one per agent per day); the HTML and TXT carry a full <strong>per-run timestamp</strong> (<code>&lt;YYYY-MM-DD-HHMMSS&gt;</code>), so re-running the same day keeps each report distinct. Praxen also writes two working artifacts during the run — a <code>&lt;agent-slug&gt;-evidence-&lt;timestamp&gt;.txt</code> evidence checkpoint and a <code>&lt;agent-slug&gt;-draft-&lt;timestamp&gt;.md</code> draft manifest. Both are recovery artifacts, not deliverables, and safe to delete after the run.</p>
 <p>The <code>.txt</code> summary is also printed to stdout during the analysis, so you can read it as the run completes.</p>
 <h2 id="where-outputs-land">Where outputs land</h2>
 <p>By default, Praxen writes to <code>./reports/</code> relative to the directory you started the coding agent in. If the directory doesn't exist, Praxen creates it.</p>

--- a/llms.txt
+++ b/llms.txt
@@ -21,7 +21,7 @@ six-category RAISE maturity framework.
 
 - [Overview](https://open-agent-ai-security.github.io/praxen/guide/index.html): what Praxen is and how it works
 - [What is Agent Behavior Verification?](https://open-agent-ai-security.github.io/praxen/guide/abv.html): the ABV concept, why agent security needs it
-- [Installation](https://open-agent-ai-security.github.io/praxen/guide/installation.html): install as a Claude Code plugin
+- [Installation](https://open-agent-ai-security.github.io/praxen/guide/installation.html): install as a Claude Code plugin or an OpenAI Codex skill
 - [Quickstart](https://open-agent-ai-security.github.io/praxen/guide/quickstart.html): author a remit, scan an agent, read the report
 - [Usage](https://open-agent-ai-security.github.io/praxen/guide/usage.html): running a real analysis
 - [Writing Worker Remits](https://open-agent-ai-security.github.io/praxen/guide/writing-remits.html): declaring an agent's authorized policy

--- a/tests/README.md
+++ b/tests/README.md
@@ -81,7 +81,7 @@ For each target:
 6. Instruct Claude Code to read `skills/behavior-verifier/SKILL.md` and analyze the workspace path.
 7. Review `<target>-analysis-<timestamp>.html` in `reports/`.
 
-> **On Codex:** the same single-target flow works — link the skill per [`docs/installation.md`](../docs/installation.md#option-b--openai-codex-agent-skill) Option B and invoke `$praxen:behavior-verifier` against the workspace (same remit + source inputs). [Quickstart](../docs/quickstart.md) has a worked `codex exec` example.
+> **On Codex:** the same single-target flow works — link the skill per the [`docs/installation.md`](../docs/installation.md#openai-codex) OpenAI Codex section and invoke `$praxen:behavior-verifier` against the workspace (same remit + source inputs). [Quickstart](../docs/quickstart.md) covers the flow — substitute your Codex invocation wherever it says `claude`.
 
 ## Full Suite Run protocol
 


### PR DESCRIPTION
The last open 1.3 checklist item (plans/RELEASE_1.3_PLAN.md rider 12). Closes out the fixable #226 leftovers verified against the current tree:

- **llms.txt** — Installation line now names both harnesses (item 9's residue; the intro already mentioned Codex)
- **docs/usage.md** — the outputs section now names *both* working artifacts (evidence checkpoint + draft manifest), so every file a reader finds in `./reports/` is explained (item 11 tail; the spec's five-files count was already fixed)
- **tests/README.md** — dead `#option-b--openai-codex-agent-skill` anchor → the real `#openai-codex` section; false "quickstart has a worked codex exec example" claim corrected (item 12 residue)
- **docs/challenging-findings.md** — bug-report path links the issue tracker directly (item 14 tail)
- **README/SECURITY dedupe** — "Working with Praxen" now has one canonical copy (docs/index.md); README summarizes + links, SECURITY.md points at the canonical copy (item 14)

**Deferred to the 2.0 docs/hero relaunch:** item 13 (front-page depth links — index.html is being rebuilt for 2.0 anyway) and item 10's per-platform invocation-spelling normalization (needs live Codex verification of what the skill registers as). Item 5 (quickstart PRAX-005) was already fixed in-tree.

`docs_build.py` re-run; only `guide/usage.html` + `guide/challenging-findings.html` regenerated. Docs-only — score-inert, no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)